### PR TITLE
Add conversion of foreach to for Intention

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -916,6 +916,10 @@
             <descriptionDirectoryName>StringToHeredocConverter</descriptionDirectoryName>
         </intentionAction>
 
+        <intentionAction>
+            <className>com.perl5.lang.perl.idea.intentions.ForeachToForConverter</className>
+            <category>Perl</category>
+        </intentionAction>
     </extensions>
 
     <application-components>

--- a/resources/intentionDescriptions/ForeachToForConverter/after.pm.template
+++ b/resources/intentionDescriptions/ForeachToForConverter/after.pm.template
@@ -1,0 +1,4 @@
+for (my $idx = 0; $idx < scalar(@list); $idx++) {
+    my $element = $list[$idx];
+    say $element;
+}

--- a/resources/intentionDescriptions/ForeachToForConverter/before.pm.template
+++ b/resources/intentionDescriptions/ForeachToForConverter/before.pm.template
@@ -1,0 +1,4 @@
+<spot>foreach</spot> my $element (@list)
+{
+    say $element;
+}

--- a/resources/intentionDescriptions/ForeachToForConverter/description.html
+++ b/resources/intentionDescriptions/ForeachToForConverter/description.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Convert a foreach to an indexed for.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/com/perl5/lang/perl/idea/intentions/ForeachToForConverter.java
+++ b/src/com/perl5/lang/perl/idea/intentions/ForeachToForConverter.java
@@ -1,0 +1,76 @@
+package com.perl5.lang.perl.idea.intentions;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.IncorrectOperationException;
+import com.perl5.lang.perl.psi.*;
+import com.perl5.lang.perl.psi.utils.PerlElementFactory;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Created by bcardoso on 7/28/16.
+ */
+public class ForeachToForConverter extends PsiElementBaseIntentionAction
+{
+	@Nls
+	@NotNull
+	@Override
+	public String getText()
+	{
+		return "Convert foreach to indexed for (Alpha)";
+	}
+
+	@Nls
+	@NotNull
+	@Override
+	public String getFamilyName()
+	{
+		return getText();
+	}
+
+	@Override
+	public boolean isAvailable(@NotNull Project project, Editor editor, @NotNull PsiElement element)
+	{
+		if (!element.isWritable()) {
+			return false;
+		}
+
+		PsiElement parent = element.getParent();
+		if (!(parent instanceof PsiPerlForeachCompound)) {
+			return false;
+		}
+
+		PsiPerlForListStatement forListStatement = ((PsiPerlForeachCompound) parent).getForListStatement();
+		return forListStatement != null
+				&& forListStatement.getExpr() instanceof PsiPerlVariableDeclarationLexical;
+	}
+
+	@Override
+	public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) throws IncorrectOperationException
+	{
+		PsiPerlForeachCompound foreachElement = (PsiPerlForeachCompound) element.getParent();
+
+		PsiPerlForListStatement forListStatement = foreachElement.getForListStatement();
+		assert forListStatement != null;
+
+		PsiPerlExpr forExpr = forListStatement.getExpr();
+		assert forExpr != null;
+
+		PsiPerlForListEpxr forListEpxr = forListStatement.getForListEpxr();
+
+		PsiPerlBlock block = foreachElement.getBlock();
+		assert block != null;
+
+		PsiPerlForCompound indexedFor = PerlElementFactory.createIndexedFor(project, forExpr, forListEpxr, block);
+		foreachElement.replace(indexedFor);
+	}
+
+	@Override
+	public boolean startInWriteAction()
+	{
+		return true;
+	}
+}

--- a/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
+++ b/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
@@ -148,13 +148,12 @@ public class PerlElementFactory
 													  @NotNull PsiPerlBlock forBlock)
 	{
 		// check if listExpr is a single array or a list expression
-		PsiPerlArrayVariable childArray = PsiTreeUtil.findChildOfType(listExpr, PsiPerlArrayVariable.class);
-		boolean isSingleArray =
-				childArray != null
+		boolean isSingleArray = listExpr.getFirstChild() instanceof PsiPerlArrayVariable
 				&& (listExpr.getChildren().length == 1);
 
 		String arrayName;
 		if (isSingleArray) {
+			PsiPerlArrayVariable childArray = (PsiPerlArrayVariable) listExpr.getFirstChild();
 			arrayName = childArray.getName();
 		} else {
 			arrayName = "list";

--- a/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
+++ b/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
@@ -20,12 +20,16 @@ import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.refactoring.RefactoringFactory;
 import com.perl5.lang.perl.fileTypes.PerlFileTypePackage;
 import com.perl5.lang.perl.psi.*;
 import com.perl5.lang.perl.psi.impl.PerlFileImpl;
 import com.perl5.lang.perl.psi.impl.PerlNamespaceElementImpl;
 import com.perl5.lang.perl.psi.impl.PerlStringContentElementImpl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,5 +142,56 @@ public class PerlElementFactory
 				createFileFromText("file.dummy", fileType, text);
 	}
 
+	public static PsiPerlForCompound createIndexedFor(@NotNull Project project,
+													  @NotNull PsiPerlExpr lexicalVariableDeclaration,
+													  @NotNull PsiPerlForListEpxr listExpr,
+													  @NotNull PsiPerlBlock forBlock)
+	{
+		// check if listExpr is a single array or a list expression
+		PsiPerlArrayVariable childArray = PsiTreeUtil.findChildOfType(listExpr, PsiPerlArrayVariable.class);
+		boolean isSingleArray =
+				childArray != null
+				&& (listExpr.getChildren().length == 1);
 
+		String arrayName;
+		if (isSingleArray) {
+			arrayName = childArray.getName();
+		} else {
+			arrayName = "list";
+		}
+
+		// Assign iterationVariable = iterationArray[$idx]
+		String assignStatementStr = String.format("%s = $%s[$idx];",
+				lexicalVariableDeclaration.getText(),
+				arrayName);
+		PsiPerlStatement assignStatement = createPsiOfTypeFromSyntax(project, assignStatementStr, PsiPerlStatement.class);
+
+		// Define where to insert the new statement
+		List<PsiPerlStatement> statementList = forBlock.getStatementList();
+		PsiElement anchorPoint = statementList.isEmpty() ? forBlock.getLastChild() : statementList.get(0);
+		forBlock.addBefore(assignStatement, anchorPoint);
+
+		String indexedForSyntax = String.format("for (my $idx = 0; $idx < scalar(@%s); $idx++) %s",
+				arrayName,
+				forBlock.getText());
+
+		PsiPerlForCompound result = createPsiOfTypeFromSyntax(project, indexedForSyntax, PsiPerlForCompound.class);
+
+		if (!isSingleArray) {
+			// declare and initialize the new array before the new for
+			String newListSyntax = String.format("my @%s = %s;\n", arrayName, listExpr.getText());
+			PsiPerlStatement newListStatement = createPsiOfTypeFromSyntax(project, newListSyntax, PsiPerlStatement.class);
+			PsiWhiteSpace newLineElement = createPsiOfTypeFromSyntax(project, newListSyntax, PsiWhiteSpace.class);
+			result.addBefore(newLineElement, result.getFirstChild());
+			result.addBefore(newListStatement, result.getFirstChild());
+		}
+
+		assert result != null : "While creating PsiPerlForCompound";
+		return result;
+	}
+
+	private static <T extends PsiElement> T createPsiOfTypeFromSyntax(Project project, String syntax, Class<T> type)
+	{
+		return PsiTreeUtil.findChildOfType(createFile(project, syntax), type);
+	}
 }


### PR DESCRIPTION
This intention will be available only when the `foreach` has a lexical variable declaration in it. This is to avoid cases where `foreach` uses the default variable `$_`.
e.g `my $path`:
```perl
foreach my $path (@INC) {
    print "$path\n";
}
```

