### PR TITLE
Improve performance when receiving a large number of added/removed files

### DIFF
--- a/src/com/perl5/lang/perl/idea/run/debugger/protocol/PerlDebuggingEventLoadedFiles.java
+++ b/src/com/perl5/lang/perl/idea/run/debugger/protocol/PerlDebuggingEventLoadedFiles.java
@@ -18,6 +18,9 @@ package com.perl5.lang.perl.idea.run.debugger.protocol;
 
 import com.perl5.lang.perl.idea.run.debugger.ui.PerlScriptsPanel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Created by hurricup on 14.05.2016.
  */
@@ -31,6 +34,10 @@ public class PerlDebuggingEventLoadedFiles extends PerlDebuggingEventBase
 	{
 		PerlScriptsPanel evalsListPanel = getDebugThread().getEvalsListPanel();
 		PerlScriptsPanel scriptListPanel = getDebugThread().getScriptListPanel();
+		List<PerlLoadedFileDescriptor> evalRemove = new ArrayList<PerlLoadedFileDescriptor>();
+		List<PerlLoadedFileDescriptor> evalAdd = new ArrayList<PerlLoadedFileDescriptor>();
+		List<PerlLoadedFileDescriptor> scriptRemove = new ArrayList<PerlLoadedFileDescriptor>();
+		List<PerlLoadedFileDescriptor> scriptAdd = new ArrayList<PerlLoadedFileDescriptor>();
 
 		for (PerlLoadedFileDescriptor fileDescriptor : add)
 		{
@@ -38,11 +45,13 @@ public class PerlDebuggingEventLoadedFiles extends PerlDebuggingEventBase
 			{
 				if (fileDescriptor.isEval())
 				{
-					evalsListPanel.replace(fileDescriptor);
+					evalRemove.add(fileDescriptor);
+					evalAdd.add(fileDescriptor);
 				}
 				else
 				{
-					scriptListPanel.replace(fileDescriptor);
+					scriptRemove.add(fileDescriptor);
+					scriptAdd.add(fileDescriptor);
 				}
 			}
 		}
@@ -54,14 +63,16 @@ public class PerlDebuggingEventLoadedFiles extends PerlDebuggingEventBase
 				if (fileDescriptor.isEval())
 				{
 					// fixme we should check if file source is loaded and mark it as unloaded or smth
-					evalsListPanel.remove(fileDescriptor);
+					evalRemove.add(fileDescriptor);
 				}
 				else
 				{
-					scriptListPanel.remove(fileDescriptor);
+					scriptRemove.add(fileDescriptor);
 				}
 			}
 		}
 
+		evalsListPanel.bulkChange(evalAdd, evalRemove);
+		scriptListPanel.bulkChange(scriptAdd, scriptRemove);
 	}
 }


### PR DESCRIPTION
This commit adds a separate implementation that is faster when adding/removing
a large number of files (in a synthetic benchamrk, the turning point is around
5000 items).

My real-world test case is ~5k new files and ~55k new evals taking almost two
minutes to be processed.

Each add()/remove() is O(myModel.size()), so the current implementation costs

    O(startSize * (startSize - 1) / 2) - (afterRemove * (afterRemove - 1) / 2)) + /* removal */
    O(afterAdd * (afterAdd - 1) / 2) - (afterRemove * (afterRemove - 1) / 2)) + /* addition */
    O(removed + added) /* one notification for each operation */

which, for small added/removed simplifies to:

    O((added + removed) * afterAdd)

for large added/removed simplifies to:

    O(startSize * startSize + afterAdd * afterAdd)

The new alternative implementation costs

    O(removed * log(startSize)) + /* removal */
    O(added) + /* addition */
    O(afterAdd) + O(afterAdd * log(afterAdd)) /* readding and sorting */
    O(afterAdd) /* a single notification for the whole range */

which (for most cases) simplifies to:

   O(afterAdd * log(afterAdd))

So the current version is good for "small" added/removed; where the exact value
needs to be determined with benchmarks.