### PR TITLE
Keep track of debugger breakpoint between multiple reconnect

### DIFF
--- a/plugin/core/src/com/perl5/lang/perl/idea/run/debugger/breakpoints/PerlLineBreakPointDescriptor.java
+++ b/plugin/core/src/com/perl5/lang/perl/idea/run/debugger/breakpoints/PerlLineBreakPointDescriptor.java
@@ -51,6 +51,14 @@ public class PerlLineBreakPointDescriptor {
     return condition;
   }
 
+  public boolean isRemove() {
+    return remove;
+  }
+
+  public boolean isSameLine(PerlLineBreakPointDescriptor descriptor) {
+    return path.equals(descriptor.path) && line == descriptor.line;
+  }
+
   @Nullable
   public static PerlLineBreakPointDescriptor createFromBreakpoint(XLineBreakpoint<PerlLineBreakpointProperties> breakpoint,
                                                                   PerlDebugThread debugThread) {


### PR DESCRIPTION
In PerlDebugThread added a new list of all currently used breakpoints to allow sending them all on debugger reconnects. Without this change none of the existing breakpoints will be sent top Perl debugger module after the first connection.

Fix for #2133 