### PR TITLE
Supress 'use strict/warnings pragma' for common Test2 includes

### DIFF
--- a/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2BaseProcessor.java
+++ b/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2BaseProcessor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2021 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.perl5.lang.perl.extensions.test2;
+
+
+import com.perl5.lang.perl.extensions.packageprocessor.PerlPackageProcessorBase;
+
+public class Test2BaseProcessor extends PerlPackageProcessorBase { }

--- a/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2BundleProcessor.java
+++ b/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2BundleProcessor.java
@@ -16,14 +16,12 @@
 
 package com.perl5.lang.perl.extensions.test2;
 
-import com.perl5.lang.perl.extensions.packageprocessor.PerlPackageProcessorBase;
+
 import com.perl5.lang.perl.extensions.packageprocessor.PerlStrictProvider;
 import com.perl5.lang.perl.extensions.packageprocessor.PerlWarningsProvider;
-import com.perl5.lang.perl.psi.impl.PerlUseStatementElement;
-import org.jetbrains.annotations.NotNull;
 
-public class Test2V0Processor extends PerlPackageProcessorBase implements
-                                                               PerlStrictProvider,
-                                                               PerlWarningsProvider {
+public class Test2BundleProcessor extends Test2BaseProcessor implements
+                                                             PerlStrictProvider,
+                                                             PerlWarningsProvider {
 
 }

--- a/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2V0Processor.java
+++ b/plugin/core/src/com/perl5/lang/perl/extensions/test2/Test2V0Processor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2021 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.perl5.lang.perl.extensions.test2;
+
+import com.perl5.lang.perl.extensions.packageprocessor.PerlPackageProcessorBase;
+import com.perl5.lang.perl.extensions.packageprocessor.PerlStrictProvider;
+import com.perl5.lang.perl.extensions.packageprocessor.PerlWarningsProvider;
+import com.perl5.lang.perl.psi.impl.PerlUseStatementElement;
+import org.jetbrains.annotations.NotNull;
+
+public class Test2V0Processor extends PerlPackageProcessorBase implements
+                                                               PerlStrictProvider,
+                                                               PerlWarningsProvider {
+
+}

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -130,8 +130,14 @@
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.ListMoreUtilsProcessor"/>
     <packageProcessor key="Test::More"
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.TestMoreProcessor"/>
+    <packageProcessor key="Test2::Bundle::Extended"
+                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2BundleProcessor"/>
+    <packageProcessor key="Test2::Bundle::More"
+                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2BundleProcessor"/>
+    <packageProcessor key="Test2::Bundle::Simple"
+                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2BundleProcessor"/>
     <packageProcessor key="Test2::V0"
-                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2V0Processor"/>
+                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2BundleProcessor"/>
     <packageProcessor key="Data::Printer"
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.DataPrinterProcessor"/>
     <packageProcessor key="DDP"

--- a/plugin/resources/META-INF/plugin.xml
+++ b/plugin/resources/META-INF/plugin.xml
@@ -130,6 +130,8 @@
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.ListMoreUtilsProcessor"/>
     <packageProcessor key="Test::More"
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.TestMoreProcessor"/>
+    <packageProcessor key="Test2::V0"
+                      implementationClass="com.perl5.lang.perl.extensions.test2.Test2V0Processor"/>
     <packageProcessor key="Data::Printer"
                       implementationClass="com.perl5.lang.perl.extensions.packageprocessor.impl.DataPrinterProcessor"/>
     <packageProcessor key="DDP"

--- a/plugin/test/packageProcessors/Test2BundleProcessorTest.java
+++ b/plugin/test/packageProcessors/Test2BundleProcessorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2021 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package packageProcessors;
+
+
+import base.PerlLightTestCase;
+import com.perl5.lang.perl.extensions.packageprocessor.PerlPackageProcessor;
+import com.perl5.lang.perl.extensions.packageprocessor.PerlStrictProvider;
+import com.perl5.lang.perl.extensions.packageprocessor.PerlWarningsProvider;
+import com.perl5.lang.perl.psi.PerlNamespaceDefinitionElement;
+import com.perl5.lang.perl.psi.impl.PerlUseStatementElement;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+
+@RunWith(Parameterized.class)
+public class Test2BundleProcessorTest extends PerlLightTestCase {
+
+  @Parameters( name = "{0}" )
+  public static Collection<String> data() {
+    return Arrays.asList(
+      "Test2BundleExtended",
+      "Test2BundleMore",
+      "Test2BundleSimple",
+      "Test2V0"
+    );
+  }
+
+  private String filename;
+
+  public Test2BundleProcessorTest(String _filename) {
+    filename = _filename;
+  }
+
+  @Before
+  public void beforeEachTestMethod() {
+    initWithFileSmart(filename);
+  }
+
+  @Test
+  public void test_Namespace() {
+    PerlNamespaceDefinitionElement namespaceDefinition = getElementAtCaret(PerlNamespaceDefinitionElement.class);
+
+    assertNotNull(namespaceDefinition);
+  }
+
+  @Test
+  public void test_UseStatement() {
+    PerlUseStatementElement useStatement = getElementAtCaret(PerlUseStatementElement.class);
+
+    assertNotNull(useStatement);
+  }
+
+  @Test
+  public void test_PackageProcessor() {
+    PerlUseStatementElement useStatement = getElementAtCaret(PerlUseStatementElement.class);
+    PerlPackageProcessor packageProcessor = useStatement.getPackageProcessor();
+
+    assertNotNull(packageProcessor);
+    assertInstanceOf(packageProcessor, PerlStrictProvider.class);
+    assertInstanceOf(packageProcessor, PerlWarningsProvider.class);
+  }
+
+  @Test
+  public void test_StrictProvider() {
+    PerlUseStatementElement useStatement = getElementAtCaret(PerlUseStatementElement.class);
+    PerlPackageProcessor packageProcessor = useStatement.getPackageProcessor();
+
+    assertInstanceOf(packageProcessor, PerlStrictProvider.class);
+  }
+
+  @Test
+  public void test_WarningsProvider() {
+    PerlUseStatementElement useStatement = getElementAtCaret(PerlUseStatementElement.class);
+    PerlPackageProcessor packageProcessor = useStatement.getPackageProcessor();
+
+    assertInstanceOf(packageProcessor, PerlWarningsProvider.class);
+  }
+
+  @Override
+  protected String getBaseDataPath() {
+    return "testData/packageProcessors/test2";
+  }
+}
+

--- a/plugin/testData/packageProcessors/test2/Test2BundleExtended.code
+++ b/plugin/testData/packageProcessors/test2/Test2BundleExtended.code
@@ -1,0 +1,5 @@
+package Test2Test;
+use Test2::Bundle::Extende<caret>d;
+
+
+1;

--- a/plugin/testData/packageProcessors/test2/Test2BundleMore.code
+++ b/plugin/testData/packageProcessors/test2/Test2BundleMore.code
@@ -1,0 +1,5 @@
+package Test2Test;
+use Test2::Bundle::Mor<caret>e;
+
+
+1;

--- a/plugin/testData/packageProcessors/test2/Test2BundleSimple.code
+++ b/plugin/testData/packageProcessors/test2/Test2BundleSimple.code
@@ -1,0 +1,5 @@
+package Test2Test;
+use Test2::Bundle::Simpl<caret>e;
+
+
+1;

--- a/plugin/testData/packageProcessors/test2/Test2V0.code
+++ b/plugin/testData/packageProcessors/test2/Test2V0.code
@@ -1,0 +1,5 @@
+package Test2Test;
+use Test2::V<caret>0;
+
+
+1;


### PR DESCRIPTION
  * Suppress "use strict/warnings pragma"

There are other relevant Test2 bundles, but since this is my first PR for the project I'm starting small - hopefully this is an appropriate solution, if not I can re-work it.