### PR TITLE
Adds an optional trailing comma to a comma-separated hash or array just before a newline.

### DIFF
--- a/plugin/core/resources/messages/PerlBundle.properties
+++ b/plugin/core/resources/messages/PerlBundle.properties
@@ -223,6 +223,7 @@ perl.formatting.deref.indexes=-> between indexes
 perl.formatting.hashref.element=Hashref element
 perl.formatting.simple.dereference=Simple dereference
 perl.formatting.statement.modifiers=Statement modifiers
+perl.formatting.comma.after.hash.value=Optional comma
 perl.code.sample.nyi=# Not yet implemented
 perl.formatting.brace.style.namespace=Namespaces
 perl.formatting.brace.style.sub=Subs, methods and funcs

--- a/plugin/core/src/com/perl5/lang/perl/idea/formatter/settings/PerlCodeStyleSettings.java
+++ b/plugin/core/src/com/perl5/lang/perl/idea/formatter/settings/PerlCodeStyleSettings.java
@@ -39,6 +39,8 @@ public class PerlCodeStyleSettings extends CustomCodeStyleSettings {
 
   public int OPTIONAL_PARENTHESES = WHATEVER;
 
+  public int OPTIONAL_COMMA = WHATEVER;
+
   public int MAIN_FORMAT = WHATEVER;
 
   public boolean SPACE_AFTER_VARIABLE_DECLARATION_KEYWORD = true;

--- a/plugin/core/src/com/perl5/lang/perl/idea/formatter/settings/PerlLanguageCodeStyleSettingsProvider.java
+++ b/plugin/core/src/com/perl5/lang/perl/idea/formatter/settings/PerlLanguageCodeStyleSettingsProvider.java
@@ -47,6 +47,7 @@ public class PerlLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSett
   private static final String GROUP_COMMENT = CodeStyleSettingsCustomizableOptions.getInstance().WRAPPING_COMMENTS;
   private static final String GROUP_LIST = CodeStyleSettingsCustomizableOptions.getInstance().WRAPPING_ARRAY_INITIALIZER;
   private static final String GROUP_ATTRIBUTES_WRAP = PerlBundle.message("perl.formatting.wrap.attributes");
+  private static final String GROUP_COMMA = PerlBundle.message("perl.formatting.comma.after.hash.value");
 
   private static final String DEFAULT_CODE_SAMPLE = PerlBundle.message("perl.code.sample.nyi");
   private static final String SPACING_CODE_SAMPLE = readCodeSample("spaces");
@@ -319,6 +320,12 @@ public class PerlLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSett
                                 PerlBundle.message("perl.formatting.main.format"),
                                 customizableOptions.SPACES_OTHER,
                                 OPTIONS_MAIN_FORMAT);
+
+      consumer.showCustomOption(PerlCodeStyleSettings.class,
+                                "OPTIONAL_COMMA",
+                                "Before newline of hash/array",
+                                GROUP_COMMA,
+                                OPTIONS_DEFAULT);
     }
   }
 

--- a/plugin/core/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
+++ b/plugin/core/src/com/perl5/lang/perl/psi/utils/PerlElementFactory.java
@@ -186,6 +186,10 @@ public class PerlElementFactory {
     return Objects.requireNonNull(createFile(project, " ").getFirstChild());
   }
 
+  public static @NotNull PsiElement createComma(Project project) {
+    return Objects.requireNonNull(createFile(project, ",").getFirstChild());
+  }
+
   public static PerlFileImpl createFile(Project project, String text) {
     return createFile(project, text, PerlFileTypePackage.INSTANCE);
   }

--- a/plugin/test/formatter/PerlFormatterSpacingTest.java
+++ b/plugin/test/formatter/PerlFormatterSpacingTest.java
@@ -857,4 +857,18 @@ public class PerlFormatterSpacingTest extends PerlFormatterTestCase {
 
   @Test
   public void testIssue1782() {doFormatTest();}
+
+  private void doTestOptionalComma(int optional_comma) {
+    getCustomSettings().OPTIONAL_COMMA = optional_comma;
+    doTestSingleSource("optionalComma");
+  }
+
+  @Test
+  public void testOptionalCommaBeforeNewlineForce() {doTestOptionalComma(FORCE);}
+
+  @Test
+  public void testOptionalCommaBeforeNewlineSuppress() {doTestOptionalComma(SUPPRESS);}
+
+  @Test
+  public void testOptionalCommaBeforeNewlineAsIs() {doTestOptionalComma(WHATEVER);}
 }

--- a/plugin/testData/formatter/perl/spacing/optionalComma.code
+++ b/plugin/testData/formatter/perl/spacing/optionalComma.code
@@ -1,0 +1,159 @@
+Fakelib::dummy->new(
+hoge => 1,
+fuga => "Foo"
+);
+Fakelib::dummy->new(
+hoge => 1,
+fuga => "Foo",
+);
+Fakelib::dummy->new(hoge => 1,fuga => "Foo");
+Fakelib::dummy->new(hoge => 1,fuga => "Foo",);
+my @test = (1,2,3);
+my @test = (1,2,3  ,);
+my @test = (1,2,3,);
+my @test = (1,
+2,3);
+my @test = (1,
+2,3,);
+my @test = (1,2,3
+);
+my @test = (1,2,3,
+);
+my @test = (
+1,
+2,
+3
+);
+my @test = (
+1,
+2,
+3,
+);
+
+my @test = [1,2,3];
+my @test = [1,2,3  ,];
+my @test = [1,
+2,3];
+my @test = [1,
+2,3,];
+my @test = [
+1,
+2,
+3
+];
+my @test = [
+1,
+2,
+3,
+];
+
+my %test = (
+hoge => 10,
+fuga => [
+"testComma",
+12345
+]
+);
+my %test = (
+hoge => 10,
+fuga => [
+"testComma",
+12345,
+]
+);
+my %test = (
+hoge => 10,
+fuga => "testComma"
+);
+my $test = {
+hoge => 10,
+fuga => "testComma2",
+};
+my $test = {
+hoge => 10,
+fuga => "testComma3"
+
+
+};
+my $test = {
+hoge => 10,
+fuga => "testComma3",
+
+
+};
+my %test = (hoge => 10,fuga => "test");
+my %test = (hoge => 10,fuga => "test",);
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [
+123,
+456,
+"aaa"
+]
+};
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [
+123,
+456,
+"aaa",
+]
+};
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [123,456,
+"aaa"],
+};
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [123,456,
+"aaa",],
+};
+my $test = {
+hoge => 10,
+piyo => [123,456,"aaa"]
+};
+my $test = {
+hoge => 10,
+piyo => [123,456,"aaa",],
+};
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [
+aaa => 12,
+bbb => 13,
+ccc => 14
+]
+};
+my $test = {
+hoge => 10,
+fuga => [123,456,"aaa"],
+piyo => [
+aaa => 12,
+bbb => 13,
+ccc => 14,
+],
+};
+my $test = {
+hoge => 10,
+fuga => "testComma2" ,
+};
+my $test = {hoge => 10,fuga => "testComma2",
+foo=> 111,bar=>123};
+my $test = {hoge => 10,fuga => "testComma2",
+foo=> 111,bar=>123 ,};
+has test => (
+is => 'ro',
+isa => 'Str'
+);
+has test => (
+is => 'ro',
+isa => 'Str',
+);
+has test => (is => 'ro',isa => 'Str');
+has test => (is => 'ro',isa => 'Str',);

--- a/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineAsIs.txt
+++ b/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineAsIs.txt
@@ -1,0 +1,159 @@
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo"
+);
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo",
+);
+Fakelib::dummy->new(hoge => 1, fuga => "Foo");
+Fakelib::dummy->new(hoge => 1, fuga => "Foo",);
+my @test = (1, 2, 3);
+my @test = (1, 2, 3,);
+my @test = (1, 2, 3,);
+my @test = (1,
+        2, 3);
+my @test = (1,
+        2, 3,);
+my @test = (1, 2, 3
+);
+my @test = (1, 2, 3,
+);
+my @test = (
+        1,
+        2,
+        3
+);
+my @test = (
+        1,
+        2,
+        3,
+);
+
+my @test = [ 1, 2, 3 ];
+my @test = [ 1, 2, 3, ];
+my @test = [ 1,
+        2, 3 ];
+my @test = [ 1,
+        2, 3, ];
+my @test = [
+        1,
+        2,
+        3
+];
+my @test = [
+        1,
+        2,
+        3,
+];
+
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345
+        ]
+);
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345,
+        ]
+);
+my %test = (
+        hoge => 10,
+        fuga => "testComma"
+);
+my $test = {
+        hoge => 10,
+        fuga => "testComma2",
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3"
+
+
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3",
+
+
+};
+my %test = (hoge => 10, fuga => "test");
+my %test = (hoge => 10, fuga => "test",);
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa"
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa",
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa" ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa", ],
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa" ]
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa", ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14,
+        ],
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma2",
+};
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123 };
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123, };
+has test => (
+        is  => 'ro',
+        isa => 'Str'
+);
+has test => (
+        is  => 'ro',
+        isa => 'Str',
+);
+has test => (is => 'ro', isa => 'Str');
+has test => (is => 'ro', isa => 'Str',);

--- a/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineForce.txt
+++ b/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineForce.txt
@@ -1,0 +1,159 @@
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo",
+);
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo",
+);
+Fakelib::dummy->new(hoge => 1, fuga => "Foo");
+Fakelib::dummy->new(hoge => 1, fuga => "Foo");
+my @test = (1, 2, 3);
+my @test = (1, 2, 3);
+my @test = (1, 2, 3);
+my @test = (1,
+        2, 3);
+my @test = (1,
+        2, 3);
+my @test = (1, 2, 3,
+);
+my @test = (1, 2, 3,
+);
+my @test = (
+        1,
+        2,
+        3,
+);
+my @test = (
+        1,
+        2,
+        3,
+);
+
+my @test = [ 1, 2, 3 ];
+my @test = [ 1, 2, 3 ];
+my @test = [ 1,
+        2, 3 ];
+my @test = [ 1,
+        2, 3 ];
+my @test = [
+        1,
+        2,
+        3,
+];
+my @test = [
+        1,
+        2,
+        3,
+];
+
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345,
+        ],
+);
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345,
+        ],
+);
+my %test = (
+        hoge => 10,
+        fuga => "testComma",
+);
+my $test = {
+        hoge => 10,
+        fuga => "testComma2",
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3",
+
+
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3",
+
+
+};
+my %test = (hoge => 10, fuga => "test");
+my %test = (hoge => 10, fuga => "test");
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa",
+        ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa",
+        ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa" ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa" ],
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa" ],
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa" ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14,
+        ],
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14,
+        ],
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma2",
+};
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123 };
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123 };
+has test => (
+        is  => 'ro',
+        isa => 'Str',
+);
+has test => (
+        is  => 'ro',
+        isa => 'Str',
+);
+has test => (is => 'ro', isa => 'Str');
+has test => (is => 'ro', isa => 'Str');

--- a/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineSuppress.txt
+++ b/plugin/testData/formatter/perl/spacing/optionalCommaBeforeNewlineSuppress.txt
@@ -1,0 +1,159 @@
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo"
+);
+Fakelib::dummy->new(
+        hoge => 1,
+        fuga => "Foo"
+);
+Fakelib::dummy->new(hoge => 1, fuga => "Foo");
+Fakelib::dummy->new(hoge => 1, fuga => "Foo");
+my @test = (1, 2, 3);
+my @test = (1, 2, 3);
+my @test = (1, 2, 3);
+my @test = (1,
+        2, 3);
+my @test = (1,
+        2, 3);
+my @test = (1, 2, 3
+);
+my @test = (1, 2, 3
+);
+my @test = (
+        1,
+        2,
+        3
+);
+my @test = (
+        1,
+        2,
+        3
+);
+
+my @test = [ 1, 2, 3 ];
+my @test = [ 1, 2, 3 ];
+my @test = [ 1,
+        2, 3 ];
+my @test = [ 1,
+        2, 3 ];
+my @test = [
+        1,
+        2,
+        3
+];
+my @test = [
+        1,
+        2,
+        3
+];
+
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345
+        ]
+);
+my %test = (
+        hoge => 10,
+        fuga => [
+                "testComma",
+                12345
+        ]
+);
+my %test = (
+        hoge => 10,
+        fuga => "testComma"
+);
+my $test = {
+        hoge => 10,
+        fuga => "testComma2"
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3"
+
+
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma3"
+
+
+};
+my %test = (hoge => 10, fuga => "test");
+my %test = (hoge => 10, fuga => "test");
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa"
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                123,
+                456,
+                "aaa"
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa" ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [ 123, 456,
+                "aaa" ]
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa" ]
+};
+my $test = {
+        hoge => 10,
+        piyo => [ 123, 456, "aaa" ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => [ 123, 456, "aaa" ],
+        piyo => [
+                aaa => 12,
+                bbb => 13,
+                ccc => 14
+        ]
+};
+my $test = {
+        hoge => 10,
+        fuga => "testComma2"
+};
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123 };
+my $test = { hoge => 10, fuga => "testComma2",
+        foo       => 111, bar => 123 };
+has test => (
+        is  => 'ro',
+        isa => 'Str'
+);
+has test => (
+        is  => 'ro',
+        isa => 'Str'
+);
+has test => (is => 'ro', isa => 'Str');
+has test => (is => 'ro', isa => 'Str');


### PR DESCRIPTION
please see: #2422

This change adds a code style option adding an optional trailing comma to a comma-separated hash or array just before a newline.
