### PR TITLE
#2451 CI pipeline optimization

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -18,28 +18,8 @@ env:
   TEST_PERL_MODULES: Mojolicious HURRICUP/Devel-Camelcadedb-v2023.1.tar.gz Devel::Cover JSON App::Prove::Plugin::PassEnv TAP::Formatter::Camelcade Devel::NYTProf Perl::Tidy Perl::Critic B::Debug Types::Serialiser
 
 jobs:
-  build:
-    name: "Build"
-    runs-on: ${{ inputs.os }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: 17
-
-      - name: Execute Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: false
-          arguments: jar instrumentTest --console plain
 
   integration-plenv:
-    needs: build
     name: Integration (plenv)
     if: ${{ inputs.os != 'windows-latest' }}
     runs-on: ${{ inputs.os }}
@@ -90,7 +70,6 @@ jobs:
             **/jacoco/*.exec  
 
   integration-asdf:
-    needs: build
     name: Integration (asdf)
     if: ${{ inputs.os != 'windows-latest' }}
     runs-on: ${{ inputs.os }}
@@ -136,9 +115,8 @@ jobs:
             **/jacoco/*.exec  
 
   integration-perlbrew:
-    needs: build
     name: Integration (perlbrew)
-    if: ${{ inputs.os != 'windows-latest' }}
+    if: ${{ inputs.os == 'ubuntu-latest' }}
     runs-on: ${{ inputs.os }}
     env:
       PERL_CONFIGURATORS: LOCAL_PERLBREW
@@ -185,7 +163,6 @@ jobs:
             **/jacoco/*.exec  
 
   integration-perlbrew-external-libs:
-    needs: build
     name: Integration (perlbrew with libs)
     if: ${{ inputs.os != 'windows-latest' }}
     runs-on: ${{ inputs.os }}
@@ -234,7 +211,6 @@ jobs:
             **/jacoco/*.exec  
 
   integration-system:
-    needs: build
     name: Integration (system)
     if: ${{ inputs.os == 'windows-latest' }}
     runs-on: ${{ inputs.os }}
@@ -278,7 +254,6 @@ jobs:
             **/jacoco/*.exec
 
   integration-docker:
-    needs: build
     name: Integration (docker)
     runs-on: ${{ inputs.os }}
     if: ${{ inputs.os == 'ubuntu-latest' }}
@@ -309,7 +284,6 @@ jobs:
 
   light-tests:
     name: Light
-    needs: build
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
@@ -336,7 +310,6 @@ jobs:
 
   heavy-tests:
     name: Heavy
-    needs: build
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push_and_pr.yml
+++ b/.github/workflows/push_and_pr.yml
@@ -15,15 +15,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+    name: "Build"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+
+      - name: Execute Gradle build
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+          arguments: jar instrumentTest --console plain
+
   codeql:
+    needs: build
     name: CodeQL
     uses: ./.github/workflows/_codeql.yml
     secrets: inherit
   qodana:
+    needs: build
     name: Qodana
     uses: ./.github/workflows/_qodana.yml
     secrets: inherit
+  plugins:
+    needs: build
+    name: Plugins
+    uses: ./.github/workflows/_build_plugins.yml
+    secrets: inherit
   tests:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -33,11 +65,13 @@ jobs:
     with:
       os: ${{ matrix.os }}
     secrets: inherit
-  plugins:
+  all-tests:
     needs: tests
-    name: Plugins
-    uses: ./.github/workflows/_build_plugins.yml
-    secrets: inherit
+    runs-on: ubuntu-latest
+    name: All tests
+    steps:
+      - name: Done
+        run: echo All tests are passed
   coverage:
     needs: tests
     name: Coverage


### PR DESCRIPTION
- build for all OSes is now done before tests, Qodana and CodeQL analysis. Later may benefit from per-os gradle caches
- plugins build is now done in parallel with tests. We need it to pass before merging PR and there is no need to wait after tests are passed
- introduced fake 'All tests' job for tests results aggregation. Unfortunately, we can't specify calling step as condition for PR (see https://github.com/community/community/discussions/49784)