### PR TITLE
Revert "[GHA] ouest/asdf-perl#22 Disable `asdf` testing for now"

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -71,7 +71,7 @@ jobs:
 
   integration-asdf:
     name: Integration (asdf)
-    if: ${{ inputs.os == 'never' }}
+    if: ${{ inputs.os != 'windows-latest' }}
     runs-on: ${{ inputs.os }}
     env:
       PERL_CONFIGURATORS: LOCAL_ASDF
@@ -96,7 +96,6 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.2 && ~/.asdf/bin/asdf plugin add perl || ~/.asdf/bin/asdf update          
           bash -c '~/.asdf/bin/asdf install perl ${{ env.PERL_TEST_VERSION }} --noman -j 8 || true'
-          ~/.asdf/bin/asdf reshim perl
           ~/.asdf/bin/asdf exec cpan install App::cpanminus
           ~/.asdf/bin/asdf exec cpanm --notest  ${{ env.TEST_PERL_MODULES }} 
           ~/.asdf/bin/asdf reshim perl


### PR DESCRIPTION
This reverts commit fe37314a33e25352d33363ad6caa7bc6c53cf072.

Fixed in ouest/asdf-perl@f1b20400f2e15f20f5c09a93331b4e0a832e06c1