### PR TITLE
Redirect STDOUT while loading modules to deparse

### DIFF
--- a/plugin/scripts/xs_parser_simple.pl
+++ b/plugin/scripts/xs_parser_simple.pl
@@ -2,6 +2,11 @@
 use File::Find;
 use B::Deparse;
 
+# Redirect STDOUT to STDERR temporarily to prevent loaded modules from mixing
+# their output into our intended output (which must be valid perl)
+open my $initial_stdout, '>&', \*STDOUT or die $!;
+open STDOUT, '>&', \*STDERR or die $!;
+
 File::Find::find( \&file_processor, @INC );
 
 my @packages = ();
@@ -21,6 +26,10 @@ sub file_processor
 
 my $deparser = B::Deparse->new();
 my %sub_map = ();
+
+# Undo the redirection
+open STDOUT, '>&', $initial_stdout or die $!;
+close $initial_stdout;
 
 print <<'EOM';
 #


### PR DESCRIPTION
If you have irssi installed, you can end up with a warning message at the top of the resultant script from deparsing (see <https://github.com/irssi/irssi/issues/1465>). This PR redirects STDOUT temporarily so that modules can't accidentally do that. Tested via dirty copy-pasting the pl file into my local IDEA installation and running "Re-generate XSubs declarations".

