### PR TITLE
Revert "Bump JetBrains/qodana-action from 2023.2.6 to 2023.2.7"

### DIFF
--- a/.github/workflows/_qodana.yml
+++ b/.github/workflows/_qodana.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Qodana Scan
-        uses: JetBrains/qodana-action@v2023.2.7
+        uses: JetBrains/qodana-action@v2023.2.6
         env:
           QODANA_LINTER: ${{ env.QODANA_TOKEN == '' && 'jetbrains/qodana-jvm-community' || 'jetbrains/qodana-jvm' }}
         with:


### PR DESCRIPTION
This reverts commit 5c5ef2584d5f6043cb26dd61961b789876038e4b.