### PR TITLE
#2789 Better artifacts names

### DIFF
--- a/embedded/build.gradle.kts
+++ b/embedded/build.gradle.kts
@@ -41,6 +41,10 @@ intellij {
 }
 
 tasks {
+  buildPlugin {
+    archiveBaseName.set("lang.perl5.embedded")
+  }
+
   withType<PrepareSandboxTask> {
     pluginJar.set(shadowJar.flatMap {
       it.archiveFile

--- a/mason/framework/build.gradle.kts
+++ b/mason/framework/build.gradle.kts
@@ -27,3 +27,9 @@ dependencies {
 intellij {
   plugins.set(listOf(project(":plugin")))
 }
+
+tasks {
+  buildPlugin {
+    archiveBaseName.set("lang.mason.framework")
+  }
+}

--- a/mason/htmlmason/build.gradle.kts
+++ b/mason/htmlmason/build.gradle.kts
@@ -43,6 +43,10 @@ intellij {
 }
 
 tasks {
+  buildPlugin {
+    archiveBaseName.set("lang.htmlmason")
+  }
+
   withType<PrepareSandboxTask> {
     pluginJar.set(shadowJar.flatMap {
       it.archiveFile

--- a/mason/mason2/build.gradle.kts
+++ b/mason/mason2/build.gradle.kts
@@ -42,6 +42,10 @@ intellij {
 }
 
 tasks {
+  buildPlugin {
+    archiveBaseName.set("lang.mason2")
+  }
+
   withType<PrepareSandboxTask> {
     pluginJar.set(shadowJar.flatMap {
       it.archiveFile

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -81,6 +81,10 @@ intellij {
 }
 
 tasks {
+  buildPlugin {
+    archiveBaseName.set("lang.perl5")
+  }
+
   withType<PrepareSandboxTask> {
     inputs.dir("scripts")
     outputs.dir("$destinationDir/${intellij.pluginName.get()}/perl")


### PR DESCRIPTION
Module-based names are not always perfect. We now use `lang.xxx` as a base name for the artifact

Fixes #2789