### PR TITLE
Moved version management from static field to service

### DIFF
--- a/plugin/core/src/main/java/com/perl5/lang/perl/psi/PerlSubCallHandlerVersionService.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/psi/PerlSubCallHandlerVersionService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2023 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.perl5.lang.perl.psi;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.util.AtomicClearableLazyValue;
+import com.intellij.openapi.util.ClearableLazyValue;
+import com.intellij.util.KeyedLazyInstance;
+import org.jetbrains.annotations.NotNull;
+
+@Service
+public final class PerlSubCallHandlerVersionService implements Disposable {
+  private final ClearableLazyValue<Integer> myVersionProvider = AtomicClearableLazyValue.createAtomic(() -> {
+    int version = 0;
+    for (KeyedLazyInstance<PerlSubCallHandler<?>> instance : PerlSubCallHandler.getExtensionPoint().getExtensions()) {
+      version += instance.getInstance().getVersion();
+    }
+    return version;
+  });
+
+  public PerlSubCallHandlerVersionService() {
+    PerlSubCallHandler.getExtensionPoint().addChangeListener(myVersionProvider::drop, this);
+  }
+
+  public static int getHandlersVersion() {
+    return getInstance().myVersionProvider.getValue();
+  }
+
+  @Override
+  public void dispose() {
+    myVersionProvider.drop();
+  }
+
+  private static @NotNull PerlSubCallHandlerVersionService getInstance() {
+    return ApplicationManager.getApplication().getService(PerlSubCallHandlerVersionService.class);
+  }
+}

--- a/plugin/core/src/main/java/com/perl5/lang/perl/psi/stubs/PerlFileElementType.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/psi/stubs/PerlFileElementType.java
@@ -27,7 +27,7 @@ import com.perl5.lang.perl.idea.EP.PerlPackageProcessorEP;
 import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlValuesManager;
 import com.perl5.lang.perl.parser.builder.PerlPsiBuilderFactory;
 import com.perl5.lang.perl.psi.PerlFile;
-import com.perl5.lang.perl.psi.PerlSubCallHandler;
+import com.perl5.lang.perl.psi.PerlSubCallHandlerVersionService;
 import com.perl5.lang.perl.psi.stubs.namespaces.PerlNamespaceDefinitionData;
 import com.perl5.lang.perl.util.PerlPackageUtil;
 import org.jetbrains.annotations.NotNull;
@@ -48,7 +48,7 @@ public final class PerlFileElementType extends IStubFileElementType<PerlFileStub
     return super.getStubVersion() +
            VERSION +
            PerlValuesManager.getVersion() +
-           PerlSubCallHandler.getHandlersVersion() +
+           PerlSubCallHandlerVersionService.getHandlersVersion() +
            PerlPackageProcessorEP.getVersion();
   }
 

--- a/plugin/core/src/main/java/com/perl5/lang/perl/psi/stubs/PerlStubIndexBase.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/psi/stubs/PerlStubIndexBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Alexandr Evstigneev
+ * Copyright 2015-2023 Alexandr Evstigneev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.intellij.psi.stubs.StubIndex;
 import com.intellij.util.Processor;
 import com.perl5.lang.perl.idea.EP.PerlPackageProcessorEP;
 import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlValuesManager;
-import com.perl5.lang.perl.psi.PerlSubCallHandler;
+import com.perl5.lang.perl.psi.PerlSubCallHandlerVersionService;
 import com.perl5.lang.perl.util.PerlStubUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,7 +40,7 @@ public abstract class PerlStubIndexBase<Psi extends PsiElement> extends StringSt
     return super.getVersion() +
            VERSION +
            PerlValuesManager.getVersion() +
-           PerlSubCallHandler.getHandlersVersion() +
+           PerlSubCallHandlerVersionService.getHandlersVersion() +
            PerlPackageProcessorEP.getVersion();
   }
 


### PR DESCRIPTION
Class initialization pathways may cause classloading errors