### PR TITLE
#2648 enabled pause debugging action

### DIFF
--- a/plugin/debugger/src/main/java/com/perl5/lang/perl/debugger/PerlDebugProcess.java
+++ b/plugin/debugger/src/main/java/com/perl5/lang/perl/debugger/PerlDebugProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 Alexandr Evstigneev
+ * Copyright 2015-2024 Alexandr Evstigneev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,8 @@ public class PerlDebugProcess extends XDebugProcess {
 
   public PerlDebugProcess(@NotNull XDebugSession session, PerlDebugProfileStateBase state, ExecutionResult executionResult) {
     super(session);
-    this.myExecutionResult = executionResult;
+    session.setPauseActionSupported(true);
+    myExecutionResult = executionResult;
     myDebugThread = new PerlDebugThread(session, state, executionResult);
     myDebugProfileState = state;
     myDebugThread.start();


### PR DESCRIPTION
Previously it was enabled by default, changed in JetBrains/intellij-community@e9a81e6

Intended behavior is - the button is always enabled to promote the feature, but if user presses it when action not available, he gets a notification with an explanation.

Fixes #2648