### PR TITLE
Use a simple check for debugger start condition

### DIFF
--- a/plugin/debugger/src/main/java/com/perl5/lang/perl/debugger/run/run/debugger/PerlDebugProfileState.java
+++ b/plugin/debugger/src/main/java/com/perl5/lang/perl/debugger/run/run/debugger/PerlDebugProfileState.java
@@ -58,9 +58,7 @@ public class PerlDebugProfileState extends PerlDebugProfileStateBase {
       if (LOG.isDebugEnabled()) {
         LOG.debug(outputType + ": " + eventText);
       }
-      if (StringUtil.startsWith(eventText, PROCESS_START_MARKER_TEXT) ||
-          StringUtil.startsWith(eventText, "##teamcity") && StringUtil.contains(eventText, PROCESS_START_MARKER_TEXT) ||
-          SystemInfo.isWindows && StringUtil.contains(eventText, PROCESS_START_MARKER_TEXT)) {
+      if (StringUtil.contains(eventText, PROCESS_START_MARKER_TEXT)) {
         LOG.debug("Marking as ready and removing listener");
         ProcessHandler processHandler = event.getProcessHandler();
         markAsReady(processHandler);


### PR DESCRIPTION
Fixes https://github.com/Camelcade/Perl5-IDEA/issues/2885

We've bitten by the issue again and again, when some extra text is output before the process start marker, the IDE will wait infinitely.

Let's simply check if the output includes the process start marker.