### PR TITLE
[Sonarcube] Work around SonarScanner crash due to outdated commons-co…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ buildscript {
 }
 
 plugins {
+  id("com.hurricup.gradle.fixcompress")
   id("idea")
   id("jacoco")
   id("org.jetbrains.intellij.platform") version "2.5.0"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,25 @@
+/**
+ * Hack plugin to put a proper version of commons-compress into the classpath of the gradle process
+ */
+
+plugins {
+  `kotlin-dsl`
+  `java-gradle-plugin`
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation("org.apache.commons:commons-compress:1.27.1")
+}
+
+gradlePlugin {
+  plugins {
+    create("fixCompressPlugin") {
+      id = "com.hurricup.gradle.fixcompress"
+      implementationClass = "com.hurricup.gradle.FixCompressPlugin"
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/com/hurricup/gradle/FixCompressPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/hurricup/gradle/FixCompressPlugin.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2025 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hurricup.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class FixCompressPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+
+  }
+}


### PR DESCRIPTION
…mpress in JetBrains Gradle plugin

SonarScanner fails at runtime with NoSuchMethodError on TarArchiveInputStream#getNextEntry(), because JetBrains' intellij-platform-gradle-plugin 2.5.0 bundles an old version of commons-compress (likely 1.20) that lacks the expected method signature.

Gradle loads classes from this plugin before resolving buildscript dependencies, so declaring the correct version in buildscript dependencies has no effect.

To work around this, we created a local Gradle plugin (`com.hurricup.gradle.fixcompress`) in `buildSrc` that depends on the correct version of commons-compress (1.27.1). By ensuring this plugin is applied early, we force Gradle to load the correct class version first.

This hack avoids patching JetBrains' plugin jar and makes the build succeed both locally and on CI, without publishing anything to Maven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Gradle plugin to the build process.
  - Added a supporting plugin to ensure compatibility with specific dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->