### PR TITLE
Fix handler lookup exceptions

### DIFF
--- a/plugin/asdf/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/asdf/AsdfHandler.java
+++ b/plugin/asdf/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/asdf/AsdfHandler.java
@@ -89,7 +89,7 @@ class AsdfHandler extends PerlRealVersionManagerHandler<AsdfData, AsdfHandler> {
         return asdfHandler;
       }
     }
-    throw new NullPointerException();
+    throw new IllegalStateException("AsdfHandler is not registered");
   }
 
   @Override

--- a/plugin/core/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/PerlRealVersionManagerData.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/PerlRealVersionManagerData.java
@@ -87,7 +87,8 @@ public abstract class PerlRealVersionManagerData<Data extends PerlRealVersionMan
     if (data instanceof PerlRealVersionManagerData<?, ?> realVersionManagerData) {
       return realVersionManagerData;
     }
-    throw new NullPointerException("Additional data supposed to be " + PerlRealVersionManagerData.class.getSimpleName() + " not " + data);
+    throw new IllegalStateException(
+      "Additional data supposed to be " + PerlRealVersionManagerData.class.getSimpleName() + " not " + data);
   }
 
   @Override

--- a/plugin/docker/src/main/java/com/perl5/lang/perl/idea/sdk/host/docker/PerlDockerHandler.java
+++ b/plugin/docker/src/main/java/com/perl5/lang/perl/idea/sdk/host/docker/PerlDockerHandler.java
@@ -129,6 +129,6 @@ class PerlDockerHandler extends PerlHostWithFileSystemHandler<PerlDockerData, Pe
         return perlDockerHandler;
       }
     }
-    throw new NullPointerException();
+    throw new IllegalStateException("PerlDockerHandler is not registered");
   }
 }

--- a/plugin/perlbrew/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/perlbrew/PerlBrewHandler.java
+++ b/plugin/perlbrew/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/perlbrew/PerlBrewHandler.java
@@ -106,7 +106,7 @@ class PerlBrewHandler extends PerlRealVersionManagerHandler<PerlBrewData, PerlBr
         return perlBrewHandler;
       }
     }
-    throw new NullPointerException();
+    throw new IllegalStateException("PerlBrewHandler is not registered");
   }
 
   @Override

--- a/plugin/plenv/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/plenv/PlenvHandler.java
+++ b/plugin/plenv/src/main/java/com/perl5/lang/perl/idea/sdk/versionManager/plenv/PlenvHandler.java
@@ -89,7 +89,7 @@ class PlenvHandler extends PerlRealVersionManagerHandler<PlenvData, PlenvHandler
         return plenvHandler;
       }
     }
-    throw new NullPointerException();
+    throw new IllegalStateException("PlenvHandler is not registered");
   }
 
   @Override


### PR DESCRIPTION
## Summary
- avoid throwing NullPointerException when handlers aren't found
- raise IllegalStateException with a clear message instead

## Testing
- `./gradlew cleanTest --no-daemon` *(fails: Daemon build incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_683fdfc048a88328b1629d312d536946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for missing or unregistered handlers, providing clearer information when certain components are not available.
	- Enhanced error reporting for unexpected data types, making issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->