### PR TITLE
Fix comment typos in PerlLightTestCaseBase

### DIFF
--- a/plugin/testFixtures/src/testFixtures/java/base/PerlLightTestCaseBase.java
+++ b/plugin/testFixtures/src/testFixtures/java/base/PerlLightTestCaseBase.java
@@ -340,7 +340,7 @@ public abstract class PerlLightTestCaseBase extends BasePlatformTestCase {
   }
 
   /**
-   * Registers disposable to be disposed after teaar down of the fixture and nullizing the module
+   * Registers disposable to be disposed after tear down of the fixture and nullifying the module
    */
   protected final void addTearDownListener(@NotNull Disposable disposable) {
     Disposer.register(getTestRootDisposable(), disposable);


### PR DESCRIPTION
## Summary
- correct typo in teardown listener comment in PerlLightTestCaseBase

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_683feb3651fc8328b9a0455a55b95ffd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling and wording in a comment to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->