### PR TITLE
Fix typos in introduce variable tests

### DIFF
--- a/plugin/src/test/java/introduce/PerlIntroduceVariableOccurrencesTest.java
+++ b/plugin/src/test/java/introduce/PerlIntroduceVariableOccurrencesTest.java
@@ -459,6 +459,6 @@ public class PerlIntroduceVariableOccurrencesTest extends PerlLightTestCase {
   public void testCodeDerefUnbraced() {doTest();}
 
   protected void doTest() {
-    doTestIntroduceVariableOccurances();
+    doTestIntroduceVariableOccurrences();
   }
 }

--- a/plugin/testFixtures/src/testFixtures/java/base/PerlLightTestCaseBase.java
+++ b/plugin/testFixtures/src/testFixtures/java/base/PerlLightTestCaseBase.java
@@ -2117,15 +2117,15 @@ public abstract class PerlLightTestCaseBase extends BasePlatformTestCase {
     UsefulTestCase.assertSameLinesWithFile(getTestResultsFilePath(), sb.toString());
   }
 
-  protected void doTestIntroduceVariableOccurances() {
+  protected void doTestIntroduceVariableOccurrences() {
     initWithFileSmartWithoutErrors();
     List<PerlIntroduceTarget> introduceTargets = PerlIntroduceTargetsHandler.getIntroduceTargets(getEditor(), getFile());
     assertTrue(!introduceTargets.isEmpty());
     List<Pair<Integer, String>> macros = new ArrayList<>();
     PerlIntroduceTargetOccurrencesCollector.collect(introduceTargets.getLast()).forEach(it -> {
-      TextRange occurenceRange = it.getTextRange();
-      macros.add(Pair.create(occurenceRange.getStartOffset(), "<occurrence>"));
-      macros.add(Pair.create(occurenceRange.getEndOffset(), "</occurrence>"));
+      TextRange occurrenceRange = it.getTextRange();
+      macros.add(Pair.create(occurrenceRange.getStartOffset(), "<occurrence>"));
+      macros.add(Pair.create(occurrenceRange.getEndOffset(), "</occurrence>"));
     });
     UsefulTestCase.assertSameLinesWithFile(getTestResultsFilePath(), getEditorTextWithMacroses(getTopLevelEditor(), macros));
   }


### PR DESCRIPTION
## Summary
- fix method name typo `doTestIntroduceVariableOccurrences`
- rename `occurrenceRange` variable

## Testing
- `./gradlew :plugin:compileTestJava` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683feade6db08328ad789ef410f97e7b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typos in method and variable names to ensure proper test execution and improve code clarity. No changes to test logic or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->