### PR TITLE
#3022 Added macro collapsing for run configurations

### DIFF
--- a/plugin/core/src/main/java/com/perl5/lang/perl/idea/run/GenericPerlRunConfiguration.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/idea/run/GenericPerlRunConfiguration.java
@@ -26,6 +26,7 @@ import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAc
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.components.PathMacroManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -115,6 +116,7 @@ public abstract class GenericPerlRunConfiguration extends LocatableConfiguration
   public void writeExternal(@NotNull Element element) throws WriteExternalException {
     super.writeExternal(element);
     XmlSerializer.serializeInto(this, element);
+    PathMacroManager.getInstance(getProject()).collapsePathsRecursively(element);
   }
 
   @Override

--- a/plugin/core/src/main/java/com/perl5/lang/perl/idea/run/run/PerlRunConfiguration.java
+++ b/plugin/core/src/main/java/com/perl5/lang/perl/idea/run/run/PerlRunConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 Alexandr Evstigneev
+ * Copyright 2015-2025 Alexandr Evstigneev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.perl5.lang.perl.idea.run.GenericPerlRunConfiguration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
-class PerlRunConfiguration extends GenericPerlRunConfiguration {
+@VisibleForTesting
+public class PerlRunConfiguration extends GenericPerlRunConfiguration {
   public PerlRunConfiguration(Project project,
                               @NotNull ConfigurationFactory factory,
                               String name) {

--- a/plugin/src/test/java/unit/perl/PerlRunConfigurationSerializationTest.kt
+++ b/plugin/src/test/java/unit/perl/PerlRunConfigurationSerializationTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2025 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.perl
+
+import base.PerlLightTestCase
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.openapi.util.io.FileUtil
+import com.perl5.lang.perl.idea.run.run.PerlRunConfiguration
+import com.perl5.lang.perl.idea.run.run.PerlRunConfigurationType
+import org.jdom.Element
+import org.junit.Test
+
+class PerlRunConfigurationSerializationTest : PerlLightTestCase() {
+  @Test
+  fun testPerlRunConfigurationSerialization() {
+    val configFile = """<configuration nameIsGenerated="true" show_console_on_std_err="false" show_console_on_std_out="false">
+  <option name="allowRunningInParallel" value="false" />
+  <option name="alternativeSdkName" />
+  <option name="compileTimeBreakpointsEnabled" value="false" />
+  <option name="consoleCharset" value="UTF-8" />
+  <option name="envs">
+    <map>
+      <entry key="ENV_PATH" value="${'$'}PROJECT_DIR$/blib/envpath" />
+    </map>
+  </option>
+  <option name="initCode" value="" />
+  <option name="nonInteractiveModeEnabled" value="false" />
+  <option name="passParentEnvs" value="true" />
+  <option name="perlArguments" value="wrong=${'$'}PROJECT_DIR$/wrong" />
+  <option name="programParameters" value="mypath=${'$'}PROJECT_DIR$/blib1" />
+  <option name="projectPathOnTarget" />
+  <option name="requiredModules" value="" />
+  <option name="scriptCharset" value="utf8" />
+  <option name="scriptPath" value="${'$'}PROJECT_DIR$/test.pl" />
+  <option name="selectedOptions">
+    <list />
+  </option>
+  <option name="startMode" value="RUN" />
+  <option name="useAlternativeSdk" value="false" />
+  <option name="workingDirectory" value="${'$'}PROJECT_DIR$/blib" />
+</configuration>""".trimIndent()
+    val configuration = PerlRunConfiguration(project, PerlRunConfigurationType.getInstance().scriptConfigurationFactory, "test")
+    configuration.readExternal(JDOMUtil.load(configFile))
+
+    assertNoMacroValue(configuration.envs["ENV_PATH"]!!, "/blib/envpath")
+    assertNoMacroValue(configuration.perlArguments!!, "/wrong")
+    assertNoMacroValue(configuration.programParameters!!, "/blib1")
+    assertNoMacroValue(configuration.workingDirectory!!, "/blib")
+    assertNoMacroValue(configuration.scriptPath!!, "/test.pl")
+
+    val rootElement = Element("configuration")
+    configuration.writeExternal(rootElement)
+    assertEquals(configFile, JDOMUtil.write(rootElement))
+  }
+
+  private fun assertNoMacroValue(stringValue: String, expectedSuffix: String) = {
+    assertFalse("Looks like $stringValue contains the macro", stringValue.contains('$'))
+    assertTrue("Value $stringValue should end with $expectedSuffix", stringValue.endsWith(expectedSuffix))
+    assertEquals(FileUtil.toSystemIndependentName("${project.basePath!!}expectedSuffix"), FileUtil.toSystemIndependentName(stringValue))
+  }
+}


### PR DESCRIPTION
Fixed #3022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file system paths in run configuration serialization for greater portability and consistency.

* **Tests**
  * Added a new test to verify correct serialization and deserialization of Perl run configurations, ensuring macros in paths and parameters are properly expanded and restored.

* **Chores**
  * Updated visibility and annotations for internal classes to support testing and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->