### PR TITLE
#2842 Moved most of the call values logic to the backend helper

### DIFF
--- a/plugin/backend/src/main/java/com/perl5/lang/perl/idea/codeInsight/typeInference/value/serialization/PerlCallObjectValueBackendHelper.kt
+++ b/plugin/backend/src/main/java/com/perl5/lang/perl/idea/codeInsight/typeInference/value/serialization/PerlCallObjectValueBackendHelper.kt
@@ -16,10 +16,15 @@
 
 package com.perl5.lang.perl.idea.codeInsight.typeInference.value.serialization
 
-import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlCallObjectValue
-import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlValue
-import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlValueDeserializer
-import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlValueSerializer
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.Processor
+import com.perl5.lang.perl.idea.codeInsight.typeInference.value.*
+import com.perl5.lang.perl.psi.mro.PerlMro
+import com.perl5.lang.perl.util.PerlPackageUtil
+
 
 class PerlCallObjectValueBackendHelper : PerlCallValueBackendHelper<PerlCallObjectValue>() {
   override val serializationId: Int
@@ -36,4 +41,59 @@ class PerlCallObjectValueBackendHelper : PerlCallValueBackendHelper<PerlCallObje
     parameter: PerlValue,
     arguments: List<PerlValue>
   ): PerlValue = PerlCallObjectValue.create(baseValue, parameter, arguments, deserializer.readNameString())
+
+  override fun computeNamespaceNames(resolvedNamespaceValue: PerlValue): MutableSet<String> =
+    if (resolvedNamespaceValue.isUnknown) mutableSetOf(PerlPackageUtil.UNIVERSAL_NAMESPACE)
+    else super.computeNamespaceNames(resolvedNamespaceValue)
+
+  override fun processCallTargets(
+    callValue: PerlCallObjectValue,
+    project: Project,
+    searchScope: GlobalSearchScope,
+    contextElement: PsiElement?,
+    namespaceNames: MutableSet<String>,
+    subNames: MutableSet<String>,
+    processor: Processor<in PsiNamedElement?>
+  ): Boolean {
+    for (contextNamespace in namespaceNames) {
+      for (currentNamespaceName in PerlMro.getLinearISA(
+        project,
+        searchScope,
+        getEffectiveNamespaceName(callValue, contextNamespace),
+        callValue.isSuper
+      )) {
+        val processingContext = ProcessingContext()
+        processingContext.processBuiltIns = false
+        if (!processItemsInNamespace(project, searchScope, subNames, processor, currentNamespaceName, processingContext, contextElement)) {
+          return false
+        }
+        if (!processingContext.processAutoload) { // marker that we've got at least one result
+          break
+        }
+      }
+    }
+    return true
+  }
+
+  override fun processTargetNamespaceElements(
+    callValue: PerlCallObjectValue,
+    contextElement: PsiElement,
+    processor: PerlNamespaceItemProcessor<in PsiNamedElement>
+  ): Boolean {
+    val project: Project = contextElement.project
+    val searchScope: GlobalSearchScope = contextElement.resolveScope
+    for (contextNamespace in callValue.namespaceNameValue.resolve(contextElement).namespaceNames) {
+      for (currentNamespaceName in PerlMro.getLinearISA(
+        project, searchScope, getEffectiveNamespaceName(callValue, contextNamespace), callValue.isSuper
+      )) {
+        if (!processTargetNamespaceElements(project, searchScope, processor, currentNamespaceName, contextElement)) {
+          return false
+        }
+      }
+    }
+    return true
+  }
+
+  private fun getEffectiveNamespaceName(callValue: PerlCallObjectValue, contextNamespace: String): String =
+    callValue.superContext ?: contextNamespace
 }

--- a/plugin/backend/src/main/java/com/perl5/lang/perl/idea/completion/util/PerlSubCompletionUtil.java
+++ b/plugin/backend/src/main/java/com/perl5/lang/perl/idea/completion/util/PerlSubCompletionUtil.java
@@ -25,6 +25,7 @@ import com.intellij.psi.PsiReference;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.perl5.lang.perl.extensions.packageprocessor.PerlExportDescriptor;
 import com.perl5.lang.perl.idea.codeInsight.typeInference.value.*;
+import com.perl5.lang.perl.idea.codeInsight.typeInference.value.serialization.PerlCallValueBackendHelper;
 import com.perl5.lang.perl.idea.completion.inserthandlers.SubSelectionHandler;
 import com.perl5.lang.perl.idea.completion.providers.processors.PerlCompletionProcessor;
 import com.perl5.lang.perl.idea.completion.providers.processors.PerlSimpleCompletionProcessor;
@@ -222,7 +223,7 @@ public class PerlSubCompletionUtil {
   public static boolean processSubsCompletionsForCallValue(@NotNull PerlSimpleCompletionProcessor completionProcessor,
                                                            @NotNull PerlCallValue perlValue,
                                                            boolean isStatic) {
-    return perlValue.processTargetNamespaceElements(
+    return PerlCallValueBackendHelper.get(perlValue).processTargetNamespaceElements(perlValue,
       completionProcessor.getLeafElement(), new PerlNamespaceItemProcessor<>() {
         @Override
         public boolean processItem(@NotNull PsiNamedElement element) {

--- a/plugin/backend/src/main/java/com/perl5/lang/perl/psi/references/PerlSubReference.java
+++ b/plugin/backend/src/main/java/com/perl5/lang/perl/psi/references/PerlSubReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 Alexandr Evstigneev
+ * Copyright 2015-2025 Alexandr Evstigneev
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.intellij.psi.ResolveResult;
 import com.intellij.psi.util.PsiUtilCore;
 import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlCallObjectValue;
 import com.perl5.lang.perl.idea.codeInsight.typeInference.value.PerlCallValue;
+import com.perl5.lang.perl.idea.codeInsight.typeInference.value.serialization.PerlCallValueBackendHelper;
 import com.perl5.lang.perl.parser.moose.MooseTokenSets;
 import com.perl5.lang.perl.psi.PerlMethod;
 import com.perl5.lang.perl.psi.PerlSubNameElement;
@@ -63,7 +64,7 @@ public class PerlSubReference extends PerlSubReferenceSimple {
     }
 
     List<PsiElement> relatedItems = new ArrayList<>();
-    perlValue.processCallTargets(element, relatedItems::add);
+    PerlCallValueBackendHelper.get(perlValue).processCallTargets(perlValue, element, relatedItems::add);
     return getResolveResults(relatedItems).toArray(ResolveResult.EMPTY_ARRAY);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of Perl call target and namespace resolution by delegating logic to specialized backend helpers, simplifying class interfaces.
  * Adjusted method visibility and removed several internal methods to centralize processing logic.
  * Updated related features to use the new backend helper approach for resolving call targets and namespace elements.

* **Chores**
  * Updated copyright year.
  * Improved internal caching and retrieval mechanisms for backend helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->