### PR TITLE
Set installer flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -342,6 +342,7 @@ val fixClientExecutable by tasks.registering(FixClientExecutable::class)
 
 val runInSplitMode by intellijPlatformTesting.runIde.registering {
   splitMode = true
+  useInstaller = providers.gradleProperty("useInstaller").get().toBoolean()
   splitModeTarget = SplitModeTarget.BOTH
   task {
     dependsOn(fixClientExecutable)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new configuration option to support the use of an installer during the split mode run process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->