### PR TITLE
#2349 #CAMELCADE-2253 Improved perl names cache updating

### DIFF
--- a/plugin/backend/src/main/java/com/perl5/lang/perl/idea/project/PerlNamesBackendCache.java
+++ b/plugin/backend/src/main/java/com/perl5/lang/perl/idea/project/PerlNamesBackendCache.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.roots.ModuleRootListener;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiTreeChangeAdapter;
 import com.intellij.psi.PsiTreeChangeEvent;
+import com.intellij.psi.impl.source.resolve.ResolveCache;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.ui.update.MergingUpdateQueue;
 import com.intellij.util.ui.update.Update;
@@ -154,7 +155,11 @@ public class PerlNamesBackendCache implements PerlNamesCache {
       subsSet.addAll(lightDefinitionsNames);
       logger.debug("Got light definitions names: ", lightDefinitionsNames.size());
       ProgressManager.checkCanceled();
-      myKnownSubs = Collections.unmodifiableSet(subsSet);
+      var newSubSet = Collections.unmodifiableSet(subsSet);
+      if (!newSubSet.equals(myKnownSubs)) {
+        myKnownSubs = newSubSet;
+        ResolveCache.getInstance(myProject).clearCache(true);
+      }
 
       Set<String> namespacesSet = new HashSet<>(PerlPackageUtilCore.CORE_PACKAGES_ALL);
 
@@ -168,7 +173,11 @@ public class PerlNamesBackendCache implements PerlNamesCache {
       Collection<String> lightNamespacesNames = lightNamespaceIndex.getAllNames(myProject);
       namespacesSet.addAll(lightNamespacesNames);
       logger.debug("Got light namespaces names: ", lightNamespacesNames.size());
-      myKnownNamespaces = Collections.unmodifiableSet(namespacesSet);
+      var newNamespaceSet = Collections.unmodifiableSet(namespacesSet);
+      if (!newNamespaceSet.equals(myKnownNamespaces)) {
+        myKnownNamespaces = newNamespaceSet;
+        ResolveCache.getInstance(myProject).clearCache(true);
+      }
 
       logger.debug("Names cache updated");
       //noinspection ReturnOfNull


### PR DESCRIPTION
- Update maps only if they did change
- Wipe resolve cache if update performed

The theory is that cache updates while resolve results are cached. But after context changes, things may change as well.

This solution is not perfect but should improve the situation. Race is still possible between update and reset. Also, lexer/parser may cache sets.

Afraid that this change may cause performance degradation, caused by resolve cache wiping. But unfortunately we don't have a performance tests. We could make it more precise and wipe only subs cache, but perl is too flexible and may do some really funny tricks.

Fixes #2349
#CAMELCADE-2253 #Fixed