### PR TITLE
Use magic trick to make PAUSE ignore package declaration from  _Deparsed_XSubs.pm

### DIFF
--- a/plugin/scripts/xs_parser_simple.pl
+++ b/plugin/scripts/xs_parser_simple.pl
@@ -68,7 +68,7 @@ foreach my $globname (sort @{get_typeglobs_snapshot()})
 foreach my $package (sort keys %sub_map)
 {
 
-    print "package $package {\n";
+    print "package\n$package {\n";
     foreach my $sub_name (sort @{$sub_map{$package}})
     {
         print "sub $sub_name\n";


### PR DESCRIPTION
Hi Team! Thank you for this Perl5 plugin 😃 

# Description
We noticed some distributions uploaded to CPAN doing namespace pollution by mistake.
In practice, the file `_Deparsed_XSubs.pm` (used for internal IDE referencing I guess) ends up sometimes being uploaded to CPAN and content indexed. See for instance [App::SimpleBackuper](https://metacpan.org/release/NOVOZHILV/App-SimpleBackuper-0.2.22) uploading [_Deparsed_XSubs.pm](https://metacpan.org/release/NOVOZHILV/App-SimpleBackuper-0.2.22/source/_Deparsed_XSubs.pm) having [indexed a ton of modules](https://cpanmeta.grinnz.com/perms?author=NOVOZHILV&module=&match_mode=prefix). It is also reported in this [thread](https://www.nntp.perl.org/group/perl.modules/2023/02/msg104140.html).

I propose this change to avoid PAUSE indexing by mistake all those package declaration.

disclaimer: this code change was not tested, not even built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted package block header formatting to use a two-line header (first line "package", second line with the package name and opening brace) for improved readability across generated outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->