### PR TITLE
IJPL-244636 Replaced groovy Maps utility with JDK equivalents

### DIFF
--- a/plugin/common/src/main/java/com/perl5/lang/perl/idea/editor/PerlBraceMatcher.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/idea/editor/PerlBraceMatcher.java
@@ -28,11 +28,11 @@ import com.perl5.lang.perl.psi.PsiPerlBlock;
 import com.perl5.lang.perl.psi.PsiPerlConditionalBlock;
 import com.perl5.lang.perl.psi.PsiPerlForCompound;
 import com.perl5.lang.perl.psi.impl.PsiPerlIfCompoundImpl;
-import org.apache.groovy.util.Maps;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.perl5.lang.perl.parser.PerlElementTypesGenerated.*;
 
@@ -50,7 +50,8 @@ public class PerlBraceMatcher implements PairedBraceMatcher {
     LEFT_BRACE_GLOB, RIGHT_BRACE_GLOB
   );
 
-  public static final Map<IElementType, IElementType> PERL_BRACES_MAP_REVERSED = Maps.inverse(PERL_BRACES_MAP);
+  public static final Map<IElementType, IElementType> PERL_BRACES_MAP_REVERSED = PERL_BRACES_MAP.entrySet().stream()
+    .collect(Collectors.toUnmodifiableMap(Map.Entry::getValue, Map.Entry::getKey));
 
   private static final BracePair[] PAIRS = new BracePair[]{
     new BracePair(REGEX_QUOTE_OPEN, REGEX_QUOTE_CLOSE, false),

--- a/plugin/common/src/main/java/com/perl5/lang/perl/idea/highlighter/PerlColorSettingsPage.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/idea/highlighter/PerlColorSettingsPage.java
@@ -25,12 +25,13 @@ import com.perl5.PerlBundle;
 import com.perl5.PerlIcons;
 import com.perl5.lang.perl.PerlLanguage;
 import com.perl5.lang.perl.psi.utils.PerlPsiUtil;
-import org.apache.groovy.util.Maps;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.Map;
+
+import static java.util.Map.entry;
 
 
 public class PerlColorSettingsPage implements ColorSettingsPage {
@@ -88,40 +89,40 @@ public class PerlColorSettingsPage implements ColorSettingsPage {
 
   @Override
   public @Nullable Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
-    return Maps.of(
-      "package", PerlSyntaxHighlighter.PERL_PACKAGE,
-      "package_core", PerlSyntaxHighlighter.PERL_PACKAGE_CORE,
-      "pragma", PerlSyntaxHighlighter.PERL_PACKAGE_PRAGMA,
-      "package_def", PerlSyntaxHighlighter.PERL_PACKAGE_DEFINITION,
-      "angle", PerlSyntaxHighlighter.PERL_ANGLE,
-      "scalar", PerlSyntaxHighlighter.PERL_SCALAR,
-      "scalar_builtin", PerlSyntaxHighlighter.PERL_SCALAR_BUILTIN,
-      "array", PerlSyntaxHighlighter.PERL_ARRAY,
-      "array_builtin", PerlSyntaxHighlighter.PERL_ARRAY_BUILTIN,
-      "hash", PerlSyntaxHighlighter.PERL_HASH,
-      "hash_builtin", PerlSyntaxHighlighter.PERL_HASH_BUILTIN,
-      "glob", PerlSyntaxHighlighter.PERL_GLOB,
-      "glob_builtin", PerlSyntaxHighlighter.PERL_GLOB_BUILTIN,
-      "handle", PerlSyntaxHighlighter.PERL_HANDLE,
-      "handle_builtin", PerlSyntaxHighlighter.PERL_HANDLE_BUILTIN,
-      "autoload", PerlSyntaxHighlighter.PERL_AUTOLOAD,
-      PerlPsiUtil.QUOTE_Q, PerlSyntaxHighlighter.PERL_SQ_STRING,
-      PerlPsiUtil.QUOTE_QX, PerlSyntaxHighlighter.PERL_DX_STRING,
-      PerlPsiUtil.QUOTE_QQ, PerlSyntaxHighlighter.PERL_DQ_STRING,
-      "rx", PerlSyntaxHighlighter.PERL_REGEX_TOKEN,
-      "block", PerlSyntaxHighlighter.PERL_BLOCK_NAME,
-      "const", PerlSyntaxHighlighter.PERL_CONSTANT,
-      "em", PerlSyntaxHighlighter.EMBED_MARKER_KEY,
-      "kw", PerlSyntaxHighlighter.PERL_KEYWORD,
-      "label", PerlSyntaxHighlighter.PERL_LABEL,
-      "sub", PerlSyntaxHighlighter.PERL_SUB,
-      "sub_builtin", PerlSyntaxHighlighter.PERL_SUB_BUILTIN,
-      "xsub", PerlSyntaxHighlighter.PERL_XSUB,
-      "sub_attr", PerlSyntaxHighlighter.PERL_SUB_ATTRIBUTE,
-      "sub_proto", PerlSyntaxHighlighter.PERL_SUB_PROTOTYPE_TOKEN,
-      "sub_declaration", PerlSyntaxHighlighter.PERL_SUB_DECLARATION,
-      "sub_definition", PerlSyntaxHighlighter.PERL_SUB_DEFINITION,
-      "ann", PerlSyntaxHighlighter.PERL_ANNOTATION
+    return Map.ofEntries(
+      entry("package", PerlSyntaxHighlighter.PERL_PACKAGE),
+      entry("package_core", PerlSyntaxHighlighter.PERL_PACKAGE_CORE),
+      entry("pragma", PerlSyntaxHighlighter.PERL_PACKAGE_PRAGMA),
+      entry("package_def", PerlSyntaxHighlighter.PERL_PACKAGE_DEFINITION),
+      entry("angle", PerlSyntaxHighlighter.PERL_ANGLE),
+      entry("scalar", PerlSyntaxHighlighter.PERL_SCALAR),
+      entry("scalar_builtin", PerlSyntaxHighlighter.PERL_SCALAR_BUILTIN),
+      entry("array", PerlSyntaxHighlighter.PERL_ARRAY),
+      entry("array_builtin", PerlSyntaxHighlighter.PERL_ARRAY_BUILTIN),
+      entry("hash", PerlSyntaxHighlighter.PERL_HASH),
+      entry("hash_builtin", PerlSyntaxHighlighter.PERL_HASH_BUILTIN),
+      entry("glob", PerlSyntaxHighlighter.PERL_GLOB),
+      entry("glob_builtin", PerlSyntaxHighlighter.PERL_GLOB_BUILTIN),
+      entry("handle", PerlSyntaxHighlighter.PERL_HANDLE),
+      entry("handle_builtin", PerlSyntaxHighlighter.PERL_HANDLE_BUILTIN),
+      entry("autoload", PerlSyntaxHighlighter.PERL_AUTOLOAD),
+      entry(PerlPsiUtil.QUOTE_Q, PerlSyntaxHighlighter.PERL_SQ_STRING),
+      entry(PerlPsiUtil.QUOTE_QX, PerlSyntaxHighlighter.PERL_DX_STRING),
+      entry(PerlPsiUtil.QUOTE_QQ, PerlSyntaxHighlighter.PERL_DQ_STRING),
+      entry("rx", PerlSyntaxHighlighter.PERL_REGEX_TOKEN),
+      entry("block", PerlSyntaxHighlighter.PERL_BLOCK_NAME),
+      entry("const", PerlSyntaxHighlighter.PERL_CONSTANT),
+      entry("em", PerlSyntaxHighlighter.EMBED_MARKER_KEY),
+      entry("kw", PerlSyntaxHighlighter.PERL_KEYWORD),
+      entry("label", PerlSyntaxHighlighter.PERL_LABEL),
+      entry("sub", PerlSyntaxHighlighter.PERL_SUB),
+      entry("sub_builtin", PerlSyntaxHighlighter.PERL_SUB_BUILTIN),
+      entry("xsub", PerlSyntaxHighlighter.PERL_XSUB),
+      entry("sub_attr", PerlSyntaxHighlighter.PERL_SUB_ATTRIBUTE),
+      entry("sub_proto", PerlSyntaxHighlighter.PERL_SUB_PROTOTYPE_TOKEN),
+      entry("sub_declaration", PerlSyntaxHighlighter.PERL_SUB_DECLARATION),
+      entry("sub_definition", PerlSyntaxHighlighter.PERL_SUB_DEFINITION),
+      entry("ann", PerlSyntaxHighlighter.PERL_ANNOTATION)
     );
   }
 

--- a/plugin/common/src/main/java/com/perl5/lang/perl/internals/PerlFeaturesTable.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/internals/PerlFeaturesTable.java
@@ -17,10 +17,11 @@
 package com.perl5.lang.perl.internals;
 
 import com.perl5.PerlBundle;
-import org.apache.groovy.util.Maps;
 import org.jetbrains.annotations.Nls;
 
 import java.util.*;
+
+import static java.util.Map.entry;
 
 /**
  * Represents internal {@code %^H}, built from {@code feature.pm}
@@ -55,33 +56,33 @@ public final class PerlFeaturesTable implements Cloneable {
   private static final String FEATURE_UNICODE_EVAL = "unieval";
   private static final String FEATURE_UNICODE_STRINGS = "unicode";
 
-  public static final Map<String, @Nls String> AVAILABLE_FEATURES = Maps.of(
-    FEATURE_APOSTROPHE_AS_PACKAGE_SEPARATOR, PerlBundle.message("feature.apostrophe"),
-    FEATURE_BAREWORD_FILEHANDLES, PerlBundle.message("perl.feature.bareword.filehandle.description"),
-    FEATURE_BITWISE, PerlBundle.message("perl.feature.bitwise.description"),
-    FEATURE_CLASS, PerlBundle.message("perl.feature.class"),
-    FEATURE_CURRENT_SUB, PerlBundle.message("perl.feature.current.sub.description"),
-    FEATURE_DECLARED_REFS, PerlBundle.message("perl.feature.declared.refs.description"),
-    FEATURE_DEFER, PerlBundle.message("perl.feature.defer.description"),
-    FEATURE_EVALBYTES, PerlBundle.message("perl.feature.evalbytes.description"),
-    FEATURE_EXTRA_PAIRED_DELIMITERS, PerlBundle.message("perl.feature.extra.delimiters.description"),
-    FEATURE_FC, PerlBundle.message("perl.feature.fc.description"),
-    FEATURE_INDIRECT, PerlBundle.message("perl.feature.indirect.description"),
-    FEATURE_ISA, PerlBundle.message("perl.feature.isa.description"),
-    FEATURE_KEYWORD_ALL, PerlBundle.message("feature.all.keyword"),
-    FEATURE_KEYWORD_ANY, PerlBundle.message("feature.any.keyword"),
-    FEATURE_MODULE_TRUE, PerlBundle.message("perl.feature.module.true"),
-    FEATURE_MULTIDIMENSIONAL, PerlBundle.message("perl.feature.multidimensional.description"),
-    FEATURE_POSTDEREF_QQ, PerlBundle.message("perl.feature.postderef.qq.description"),
-    FEATURE_REFALIASING, PerlBundle.message("perl.feature.refaliasing.description"),
-    FEATURE_SAY, PerlBundle.message("perl.feature.say.description"),
-    FEATURE_SIGNATURES, PerlBundle.message("perl.feature.signatures.description"),
-    FEATURE_SMARTMATCH, PerlBundle.message("feature.enabled.smartmatch.operator"),
-    FEATURE_STATE, PerlBundle.message("perl.feature.state.description"),
-    FEATURE_SWITCH, PerlBundle.message("perl.feature.switch.description"),
-    FEATURE_TRY, PerlBundle.message("perl.feature.try.description"),
-    FEATURE_UNICODE_EVAL, PerlBundle.message("perl.feature.unicode.eval.description"),
-    FEATURE_UNICODE_STRINGS, PerlBundle.message("perl.feature.unicode.strings.description")
+  public static final Map<String, @Nls String> AVAILABLE_FEATURES = Map.ofEntries(
+    entry(FEATURE_APOSTROPHE_AS_PACKAGE_SEPARATOR, PerlBundle.message("feature.apostrophe")),
+    entry(FEATURE_BAREWORD_FILEHANDLES, PerlBundle.message("perl.feature.bareword.filehandle.description")),
+    entry(FEATURE_BITWISE, PerlBundle.message("perl.feature.bitwise.description")),
+    entry(FEATURE_CLASS, PerlBundle.message("perl.feature.class")),
+    entry(FEATURE_CURRENT_SUB, PerlBundle.message("perl.feature.current.sub.description")),
+    entry(FEATURE_DECLARED_REFS, PerlBundle.message("perl.feature.declared.refs.description")),
+    entry(FEATURE_DEFER, PerlBundle.message("perl.feature.defer.description")),
+    entry(FEATURE_EVALBYTES, PerlBundle.message("perl.feature.evalbytes.description")),
+    entry(FEATURE_EXTRA_PAIRED_DELIMITERS, PerlBundle.message("perl.feature.extra.delimiters.description")),
+    entry(FEATURE_FC, PerlBundle.message("perl.feature.fc.description")),
+    entry(FEATURE_INDIRECT, PerlBundle.message("perl.feature.indirect.description")),
+    entry(FEATURE_ISA, PerlBundle.message("perl.feature.isa.description")),
+    entry(FEATURE_KEYWORD_ALL, PerlBundle.message("feature.all.keyword")),
+    entry(FEATURE_KEYWORD_ANY, PerlBundle.message("feature.any.keyword")),
+    entry(FEATURE_MODULE_TRUE, PerlBundle.message("perl.feature.module.true")),
+    entry(FEATURE_MULTIDIMENSIONAL, PerlBundle.message("perl.feature.multidimensional.description")),
+    entry(FEATURE_POSTDEREF_QQ, PerlBundle.message("perl.feature.postderef.qq.description")),
+    entry(FEATURE_REFALIASING, PerlBundle.message("perl.feature.refaliasing.description")),
+    entry(FEATURE_SAY, PerlBundle.message("perl.feature.say.description")),
+    entry(FEATURE_SIGNATURES, PerlBundle.message("perl.feature.signatures.description")),
+    entry(FEATURE_SMARTMATCH, PerlBundle.message("feature.enabled.smartmatch.operator")),
+    entry(FEATURE_STATE, PerlBundle.message("perl.feature.state.description")),
+    entry(FEATURE_SWITCH, PerlBundle.message("perl.feature.switch.description")),
+    entry(FEATURE_TRY, PerlBundle.message("perl.feature.try.description")),
+    entry(FEATURE_UNICODE_EVAL, PerlBundle.message("perl.feature.unicode.eval.description")),
+    entry(FEATURE_UNICODE_STRINGS, PerlBundle.message("perl.feature.unicode.strings.description"))
   );
 
   private static final List<String> FEATURES_5_10 = List.of(
@@ -113,51 +114,51 @@ public final class PerlFeaturesTable implements Cloneable {
     List.of(FEATURE_BITWISE, FEATURE_CURRENT_SUB, FEATURE_EVALBYTES, FEATURE_FC, FEATURE_ISA, FEATURE_MODULE_TRUE, FEATURE_POSTDEREF_QQ,
             FEATURE_SAY, FEATURE_SIGNATURES, FEATURE_STATE, FEATURE_TRY, FEATURE_UNICODE_EVAL, FEATURE_UNICODE_STRINGS);
 
-  public static final Map<String, List<String>> AVAILABLE_FEATURES_BUNDLES = Maps.of(
-    "all", new ArrayList<>(AVAILABLE_FEATURES.keySet()),
-    "default",
-    Arrays.asList(FEATURE_APOSTROPHE_AS_PACKAGE_SEPARATOR, FEATURE_BAREWORD_FILEHANDLES, FEATURE_INDIRECT, FEATURE_MULTIDIMENSIONAL,
-                  FEATURE_SMARTMATCH),
+  public static final Map<String, List<String>> AVAILABLE_FEATURES_BUNDLES = Map.ofEntries(
+    entry("all", new ArrayList<>(AVAILABLE_FEATURES.keySet())),
+    entry("default",
+          Arrays.asList(FEATURE_APOSTROPHE_AS_PACKAGE_SEPARATOR, FEATURE_BAREWORD_FILEHANDLES, FEATURE_INDIRECT, FEATURE_MULTIDIMENSIONAL,
+                        FEATURE_SMARTMATCH)),
 
-    "5.9.5", FEATURES_5_10,
-    "5.10", FEATURES_5_10,
+    entry("5.9.5", FEATURES_5_10),
+    entry("5.10", FEATURES_5_10),
 
-    "5.11", FEATURES_5_11,
-    "5.12", FEATURES_5_11,
-    "5.13", FEATURES_5_11,
-    "5.14", FEATURES_5_11,
+    entry("5.11", FEATURES_5_11),
+    entry("5.12", FEATURES_5_11),
+    entry("5.13", FEATURES_5_11),
+    entry("5.14", FEATURES_5_11),
 
-    "5.15", FEATURES_5_15,
-    "5.16", FEATURES_5_15,
-    "5.17", FEATURES_5_15,
-    "5.18", FEATURES_5_15,
-    "5.19", FEATURES_5_15,
-    "5.20", FEATURES_5_15,
-    "5.21", FEATURES_5_15,
-    "5.22", FEATURES_5_15,
+    entry("5.15", FEATURES_5_15),
+    entry("5.16", FEATURES_5_15),
+    entry("5.17", FEATURES_5_15),
+    entry("5.18", FEATURES_5_15),
+    entry("5.19", FEATURES_5_15),
+    entry("5.20", FEATURES_5_15),
+    entry("5.21", FEATURES_5_15),
+    entry("5.22", FEATURES_5_15),
 
-    "5.23", FEATURES_5_23,
-    "5.24", FEATURES_5_23,
-    "5.25", FEATURES_5_23,
-    "5.26", FEATURES_5_23,
+    entry("5.23", FEATURES_5_23),
+    entry("5.24", FEATURES_5_23),
+    entry("5.25", FEATURES_5_23),
+    entry("5.26", FEATURES_5_23),
 
-    "5.27", FEATURES_5_27,
-    "5.28", FEATURES_5_27,
-    "5.29", FEATURES_5_27,
-    "5.30", FEATURES_5_27,
-    "5.31", FEATURES_5_27,
-    "5.32", FEATURES_5_27,
-    "5.33", FEATURES_5_27,
-    "5.34", FEATURES_5_27,
+    entry("5.27", FEATURES_5_27),
+    entry("5.28", FEATURES_5_27),
+    entry("5.29", FEATURES_5_27),
+    entry("5.30", FEATURES_5_27),
+    entry("5.31", FEATURES_5_27),
+    entry("5.32", FEATURES_5_27),
+    entry("5.33", FEATURES_5_27),
+    entry("5.34", FEATURES_5_27),
 
-    "5.35", FEATURES_5_35,
-    "5.36", FEATURES_5_35,
+    entry("5.35", FEATURES_5_35),
+    entry("5.36", FEATURES_5_35),
 
-    "5.37", FEATURES_5_37,
-    "5.38", FEATURES_5_37,
+    entry("5.37", FEATURES_5_37),
+    entry("5.38", FEATURES_5_37),
 
-    "5.40", FEATURES_5_39,
-    "5.42", FEATURES_5_41
+    entry("5.40", FEATURES_5_39),
+    entry("5.42", FEATURES_5_41)
   );
 
   private Map<String, Boolean> featuresMap;

--- a/plugin/common/src/main/java/com/perl5/lang/perl/internals/PerlVersion.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/internals/PerlVersion.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.xmlb.annotations.Tag;
 import com.perl5.PerlBundle;
 import com.perl5.lang.perl.util.PerlUtil;
-import org.apache.groovy.util.Maps;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
+
+import static java.util.Map.entry;
 
 import static com.perl5.lang.perl.internals.PerlVersionRegexps.*;
 
@@ -64,22 +65,22 @@ public final class PerlVersion implements Comparable<PerlVersion> {
     V5_10, V5_12, V5_14, V5_16, V5_18, V5_20, V5_22, V5_24, V5_26, V5_28, V5_30, V5_32, V5_34, V5_36, V5_38, V5_40, V5_42
   );
 
-  public static final Map<PerlVersion, @Nls String> PERL_VERSION_DESCRIPTIONS = Maps.of(
-    V5_10, PerlBundle.message("perl.version.description.5.10"),
-    V5_12, PerlBundle.message("perl.version.description.5.12"),
-    V5_14, PerlBundle.message("perl.version.description.5.14"),
-    V5_16, PerlBundle.message("perl.version.description.5.16"),
-    V5_18, PerlBundle.message("perl.version.description.5.18"),
-    V5_20, PerlBundle.message("perl.version.description.5.20"),
-    V5_22, PerlBundle.message("perl.version.description.5.22"),
-    V5_24, PerlBundle.message("perl.version.description.5.24"),
-    V5_26, PerlBundle.message("perl.version.description.5.26"),
-    V5_28, PerlBundle.message("perl.version.description.5.28"),
-    V5_30, PerlBundle.message("perl.version.description.5.30"),
-    V5_32, PerlBundle.message("perl.version.description.5.32"),
-    V5_34, PerlBundle.message("perl.version.description.5.34"),
-    V5_36, PerlBundle.message("perl.version.description.5.36"),
-    V5_38, PerlBundle.message("perl.version.description.5.38")
+  public static final Map<PerlVersion, @Nls String> PERL_VERSION_DESCRIPTIONS = Map.ofEntries(
+    entry(V5_10, PerlBundle.message("perl.version.description.5.10")),
+    entry(V5_12, PerlBundle.message("perl.version.description.5.12")),
+    entry(V5_14, PerlBundle.message("perl.version.description.5.14")),
+    entry(V5_16, PerlBundle.message("perl.version.description.5.16")),
+    entry(V5_18, PerlBundle.message("perl.version.description.5.18")),
+    entry(V5_20, PerlBundle.message("perl.version.description.5.20")),
+    entry(V5_22, PerlBundle.message("perl.version.description.5.22")),
+    entry(V5_24, PerlBundle.message("perl.version.description.5.24")),
+    entry(V5_26, PerlBundle.message("perl.version.description.5.26")),
+    entry(V5_28, PerlBundle.message("perl.version.description.5.28")),
+    entry(V5_30, PerlBundle.message("perl.version.description.5.30")),
+    entry(V5_32, PerlBundle.message("perl.version.description.5.32")),
+    entry(V5_34, PerlBundle.message("perl.version.description.5.34")),
+    entry(V5_36, PerlBundle.message("perl.version.description.5.36")),
+    entry(V5_38, PerlBundle.message("perl.version.description.5.38"))
   );
 
   @Tag("isAlpha")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code to use standard Java utilities instead of third-party Groovy dependencies for map construction and manipulation, improving code maintainability and reducing external dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Camelcade/Perl5-IDEA/pull/3213)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->