### PR TITLE
Fix smart indent on Enter inside a here-doc with an injected language

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -425,6 +425,7 @@ intellijPlatform {
       bundledPluginList.add("Docker")
       bundledPluginList.add(providers.gradleProperty("coveragePlugin").get())
       bundledPluginList.add(providers.gradleProperty("remoteRunPlugin").get())
+      bundledPluginList.add("com.intellij.database")
       IntelliJPlatformType.IntellijIdeaUltimate to platformVersionProvider.get()
     }
   }

--- a/plugin/common/src/main/java/com/perl5/lang/perl/idea/editor/smartkeys/PerlEnterInInjectionHandler.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/idea/editor/smartkeys/PerlEnterInInjectionHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2025 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.perl5.lang.perl.idea.editor.smartkeys;
+
+import com.intellij.lang.injection.InjectedLanguageManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.perl5.lang.perl.PerlLanguage;
+import com.perl5.lang.perl.psi.impl.PerlHeredocElementImpl;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Restores smart indent inside a here-doc with an injected language.
+ * <p>
+ * When the caret is inside an injection, {@code EnterHandler} resolves the language from the data context and gets the
+ * injected one, so the platform picks the {@code LineIndentProvider} of the injected language and never falls back to the
+ * formatter. The host formatting model, the very one reformatting uses to lay the fragment out correctly, is not consulted
+ * and the new line ends up in the first column. Re-running the formatter based indent adjustment for that single line
+ * yields exactly what reformatting would produce.
+ */
+public class PerlEnterInInjectionHandler extends PerlEnterHandler {
+  @Override
+  protected Result doPostProcessEnter(@NotNull PsiFile file, @NotNull Editor editor, @NotNull DataContext dataContext) {
+    Project project = file.getProject();
+    InjectedLanguageManager injectedManager = InjectedLanguageManager.getInstance(project);
+    PsiFile hostFile = injectedManager.getTopLevelFile(file);
+    if (hostFile == file || !hostFile.getLanguage().is(PerlLanguage.INSTANCE)) {
+      return Result.Continue;
+    }
+
+    Document hostDocument = PsiDocumentManager.getInstance(project).getDocument(hostFile);
+    if (hostDocument == null) {
+      return Result.Continue;
+    }
+
+    int hostOffset = injectedManager.injectedToHost(file, editor.getCaretModel().getOffset());
+    PsiElement elementAtCaret = hostFile.findElementAt(hostOffset);
+    PerlHeredocElementImpl heredoc = PsiTreeUtil.getParentOfType(elementAtCaret, PerlHeredocElementImpl.class, false);
+    if (heredoc == null) {
+      return Result.Continue;
+    }
+
+    PsiDocumentManager.getInstance(project).commitDocument(hostDocument);
+    CodeStyleManager.getInstance(project).adjustLineIndent(hostFile, hostOffset);
+    return Result.Continue;
+  }
+}

--- a/plugin/common/src/main/java/com/perl5/lang/perl/idea/formatter/PerlInjectedLanguageBlockWrapper.java
+++ b/plugin/common/src/main/java/com/perl5/lang/perl/idea/formatter/PerlInjectedLanguageBlockWrapper.java
@@ -92,7 +92,26 @@ public class PerlInjectedLanguageBlockWrapper implements Block {
 
   @Override
   public @NotNull ChildAttributes getChildAttributes(int newChildIndex) {
-    return myOriginal.getChildAttributes(newChildIndex);
+    ChildAttributes originalAttributes = myOriginal.getChildAttributes(newChildIndex);
+    if (originalAttributes.getAlignment() != null) {
+      return originalAttributes;
+    }
+    Indent originalIndent = originalAttributes.getChildIndent();
+    if (originalIndent != null && originalIndent.getType() == Indent.Type.SPACES) {
+      return originalAttributes;
+    }
+    // The injected formatter answered with a generic indent and no alignment. A generic indent is resolved
+    // against the host file indent options and drifts away from the fragment's own layout. If the sibling
+    // this line is being inserted before is positioned with an explicit space indent (sql clause elements,
+    // for example), reuse it, so the new line lands where reformatting would put that sibling.
+    List<Block> children = getSubBlocks();
+    if (newChildIndex >= 0 && newChildIndex < children.size()) {
+      Indent siblingIndent = children.get(newChildIndex).getIndent();
+      if (siblingIndent != null && siblingIndent.getType() == Indent.Type.SPACES) {
+        return new ChildAttributes(siblingIndent, null);
+      }
+    }
+    return originalAttributes;
   }
 
   @Override

--- a/plugin/common/src/main/resources/perl5.plugin.common.main.xml
+++ b/plugin/common/src/main/resources/perl5.plugin.common.main.xml
@@ -115,6 +115,7 @@
     <extendWordSelectionHandler implementation="com.perl5.lang.perl.idea.editor.PerlVariableSelectionHandler"/>
     <enterHandlerDelegate implementation="com.perl5.lang.perl.idea.editor.smartkeys.PerlEnterHeredocClosingHandler"
                           id="PerlEnterHandler" order="first"/>
+    <enterHandlerDelegate implementation="com.perl5.lang.perl.idea.editor.smartkeys.PerlEnterInInjectionHandler"/>
     <enterHandlerDelegate implementation="com.perl5.lang.perl.idea.editor.smartkeys.PerlEnterInBracketsHandler"/>
     <enterHandlerDelegate implementation="com.perl5.lang.perl.idea.editor.smartkeys.PerlEnterInCommentHandler"/>
     <editorHighlighterProvider filetype="Perl5 Script"

--- a/plugin/src/test/java/formatter/PerlFormatterInjectedHeredocEnterTest.java
+++ b/plugin/src/test/java/formatter/PerlFormatterInjectedHeredocEnterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2025 Alexandr Evstigneev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package formatter;
+
+
+import org.junit.Test;
+
+public class PerlFormatterInjectedHeredocEnterTest extends PerlFormatterTestCase {
+  @Override
+  protected String getBaseDataPath() {
+    return "formatter/perl/injected_heredoc_enter";
+  }
+
+  @Test
+  public void testUnindentableNested() {doTestEnter();}
+
+  @Test
+  public void testUnindentableTopLevel() {doTestEnter();}
+
+  @Test
+  public void testIndentableNested() {doTestEnter();}
+}

--- a/plugin/src/test/java/formatter/PerlFormatterInjectedHeredocEnterTest.java
+++ b/plugin/src/test/java/formatter/PerlFormatterInjectedHeredocEnterTest.java
@@ -33,4 +33,13 @@ public class PerlFormatterInjectedHeredocEnterTest extends PerlFormatterTestCase
 
   @Test
   public void testIndentableNested() {doTestEnter();}
+
+  @Test
+  public void testSqlAfterWhere() {doTestEnter();}
+
+  @Test
+  public void testSqlBetweenAnds() {doTestEnter();}
+
+  @Test
+  public void testSqlReformat() {doFormatTest();}
 }

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/indentableNested.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/indentableNested.code
@@ -1,0 +1,8 @@
+{
+<<~HTML;
+    <html>
+    <div><caret>
+    </div>
+    </html>
+    HTML
+}

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/indentableNested.pl.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/indentableNested.pl.txt
@@ -1,0 +1,9 @@
+{
+<<~HTML;
+    <html>
+    <div>
+        <caret>
+    </div>
+    </html>
+    HTML
+}

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlAfterWhere.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlAfterWhere.code
@@ -1,0 +1,7 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1<caret>
+  AND b = 2
+  AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlAfterWhere.pl.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlAfterWhere.pl.txt
@@ -1,0 +1,8 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1
+  <caret>
+  AND b = 2
+  AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlBetweenAnds.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlBetweenAnds.code
@@ -1,0 +1,7 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1
+  AND b = 2<caret>
+  AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlBetweenAnds.pl.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlBetweenAnds.pl.txt
@@ -1,0 +1,8 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1
+  AND b = 2
+  <caret>
+  AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlReformat.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlReformat.code
@@ -1,0 +1,7 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1
+     AND b = 2
+ AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlReformat.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/sqlReformat.txt
@@ -1,0 +1,7 @@
+$r = SqlQuery(<<SQL);
+SELECT *
+FROM tblPackage
+WHERE a = 1
+  AND b = 2
+  AND c = 3
+SQL

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableNested.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableNested.code
@@ -1,0 +1,6 @@
+<<HTML;
+<html>
+<div><caret>
+</div>
+</html>
+HTML

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableNested.pl.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableNested.pl.txt
@@ -1,0 +1,7 @@
+<<HTML;
+<html>
+<div>
+    <caret>
+</div>
+</html>
+HTML

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableTopLevel.code
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableTopLevel.code
@@ -1,0 +1,4 @@
+<<HTML;
+<html><caret>
+</html>
+HTML

--- a/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableTopLevel.pl.txt
+++ b/plugin/src/test/resources/formatter/perl/injected_heredoc_enter/unindentableTopLevel.pl.txt
@@ -1,0 +1,5 @@
+<<HTML;
+<html>
+<caret>
+</html>
+HTML


### PR DESCRIPTION
Fixes #3244

### Problem

Pressing <kbd>Enter</kbd> inside a here-doc with an injected language always puts the caret in the first column, while `Reformat Code` lays the very same fragment out correctly. Reproduces with any injected language and with both `<<MARKER` and `<<~MARKER`.

### Cause

When the caret is inside an injection, `EnterHandler` takes the language from the data context and receives the **injected** one, not the host. `CodeStyle.getLineIndent` then looks up a `LineIndentProvider` for that language, and the formatter fallback never runs, so the host formatting model is not consulted at all.

Confirmed by instrumentation. With probes in `PerlIndentProcessor.getChildIndent`, `PerlHeredocFormattingBlock.getChildAttributes` and `PerlInjectedLanguageBlockWrapper.getChildAttributes`:

| | Enter in plain perl code | Enter inside an injected here-doc |
|---|---|---|
| `LineIndentProvider` lookup performed with | `Language: Perl5` | `Language: HTML` |
| `PerlIndentProcessor.getChildIndent` | 8 hits | **0 hits** |
| `PerlHeredocFormattingBlock.getChildAttributes` | - | **0 hits** |
| `PerlInjectedLanguageBlockWrapper.getChildAttributes` | - | **0 hits** |

### What this is not

The formatting blocks are fine. Three candidate patches each left the produced text byte for byte identical, verified by running the tests against answer files captured before the change:

- applying the absolute-none normalization of `getIndent`/`getAlignment` inside `PerlInjectedLanguageBlockWrapper.getChildAttributes`;
- removing `final` from `PerlFormattingBlock.getChildAttributes` and overriding it in the here-doc block;
- returning `ChildAttributes.DELEGATE_TO_PREV_CHILD` from the here-doc block.

None of them is included here.

### Fix

A `postProcessEnter` delegate that re-runs the formatter based indent adjustment for the new line. It returns `Result.Continue` immediately unless the file is injected, its top level file is perl, and the caret sits inside a here-doc, so no other language and no plain perl code is affected. The offset is translated with `injectedToHost` because the platform hands the delegate the injected file and the injected editor.

The indent it produces matches what `Reformat Code` produces for the same fragment, which is what the existing `PerlFormatterInjectedHeredocTest` answer files already define as correct.

### Tests

`PerlFormatterInjectedHeredocEnterTest`, three cases:

- `unindentableNested` - nested position in an unindentable here-doc, expects the injected language indent;
- `indentableNested` - same in an indentable one, expects the here-doc base indent plus the injected one;
- `unindentableTopLevel` - top level position, where the first column is the correct answer, as a guard.

The first two fail without the fix and pass with it. Full `formatter`, `editor` and `intellilang` suites: **1266 tests, no failures**.

### Manual verification

Built from this branch and installed into IntelliJ IDEA 2026.2. Enter now indents inside injected here-docs, `Reformat Code` and plain perl indentation are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indentation when pressing Enter inside embedded HTML and SQL content in Perl here-documents.
  * Preserves appropriate formatter-based indentation for nested and top-level content.
  * Improved formatting consistency around multiline SQL conditions.

* **Tests**
  * Added coverage for embedded HTML and SQL here-document indentation and reformatting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->